### PR TITLE
Patched the Address object, repository and service 

### DIFF
--- a/src/Merchello.Core/Merchello.Core.csproj
+++ b/src/Merchello.Core/Merchello.Core.csproj
@@ -90,6 +90,7 @@
       <SubType>Code</SubType>
     </Compile>
     <Compile Include="Persistence\Factories\AddressFactory.cs" />
+    <Compile Include="Persistence\Repositories\ICustomerRepository.cs" />
     <Compile Include="Persistence\Mappers\AddressMapper.cs" />
     <Compile Include="Persistence\Mappers\MerchelloMappers.cs" />
     <Compile Include="Persistence\Migrations\Initial\BaseDataCreation.cs" />
@@ -165,7 +166,6 @@
     <Compile Include="Persistence\Repositories\IAddressRepository.cs" />
     <Compile Include="Persistence\RepositoryFactory.cs" />
     <Compile Include="Persistence\Repositories\CustomerRepository.cs" />
-    <Compile Include="Persistence\Repositories\ICustomerRepository.cs" />
     <Compile Include="Persistence\Repositories\MerchelloPetaPocoRepositoryBase.cs" />
     <Compile Include="Persistence\Repositories\MerchelloRepositoryBase.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/src/Merchello.Core/Models/Address.cs
+++ b/src/Merchello.Core/Models/Address.cs
@@ -6,12 +6,12 @@ using Merchello.Core.Models.TypeFields;
 
 namespace Merchello.Core.Models
 {
+
     [Serializable]
     [DataContract(IsReference = true)]
     public class Address : IdEntity, IAddress
     {
-        private int _id;
-        private Guid _customerPk;
+        private readonly Guid _customerPk;
         private string _label;
         private string _fullName;
         private string _company;
@@ -24,107 +24,232 @@ namespace Merchello.Core.Models
         private string _countryCode;
         private string _phone;
 
-        public Address(int id, Guid customerPk, string label)
+        ///TODO: We need to talk about the contstructor.  An empty address does not make a lot of sense.
+        public Address(Guid customerPk)
         {
-            _id = id;
             _customerPk = customerPk;
-            _label = label;
         }
-
-        private static readonly PropertyInfo IdSelector = ExpressionHelper.GetPropertyInfo<Address, int>(x => x.Id);
-        private static readonly PropertyInfo CustomerPkSelector = ExpressionHelper.GetPropertyInfo<Address, Guid>(x => x.CustomerPk);
+        
         private static readonly PropertyInfo LabelSelector = ExpressionHelper.GetPropertyInfo<Address, string>(x => x.Label);
+        private static readonly PropertyInfo FullNameSelector = ExpressionHelper.GetPropertyInfo<Address, string>(x => x.FullName);
+        private static readonly PropertyInfo CompanySelector = ExpressionHelper.GetPropertyInfo<Address, string>(x => x.Company);
+        private static readonly PropertyInfo AddressTypeFieldSelector = ExpressionHelper.GetPropertyInfo<Address, Guid>(x => x.AddressTypeFieldKey);
+        private static readonly PropertyInfo Address1Selector = ExpressionHelper.GetPropertyInfo<Address, string>(x => x.Address1);
+        private static readonly PropertyInfo Address2Selector = ExpressionHelper.GetPropertyInfo<Address, string>(x => x.Address2);
+        private static readonly PropertyInfo LocalitySelector = ExpressionHelper.GetPropertyInfo<Address, string>(x => x.Locality);
+        private static readonly PropertyInfo RegionSelector = ExpressionHelper.GetPropertyInfo<Address, string>(x => x.Region);
+        private static readonly PropertyInfo PostalCodeSelector = ExpressionHelper.GetPropertyInfo<Address, string>(x => x.PostalCode);
+        private static readonly PropertyInfo CountryCodeSelector = ExpressionHelper.GetPropertyInfo<Address, string>(x => x.CountryCode);
+        private static readonly PropertyInfo PhoneSelector = ExpressionHelper.GetPropertyInfo<Address, string>(x => x.Phone);
 
-
+        /// <summary>
+        /// The customer key (pk) associated with the address
+        /// </summary>
+        [DataMember]
         public Guid CustomerPk
         {
             get { return _customerPk; }
-            set { _customerPk = value; }
         }
 
+        /// <summary>
+        /// The descriptive label for the address
+        /// </summary>
+        [DataMember]
         public string Label
         {
             get { return _label; }
-            set { _label = value; }
+            set 
+            { 
+                SetPropertyValueAndDetectChanges(o =>
+                {
+                    _label = value;
+                    return _label;
+                }, _label, LabelSelector); 
+            }
         }
 
+        /// <summary>
+        /// The full name for the address
+        /// </summary>
+        /// <remarks>
+        /// TODO: do we need this????
+        /// </remarks>
+        [DataMember]
         public string FullName
         {
             get { return _fullName; }
-            set { _fullName = value; }
+            set
+            {
+                SetPropertyValueAndDetectChanges(o =>
+                { 
+                    _fullName = value ;
+                    return _label;
+                }, _fullName, FullNameSelector);
+            }
         }
 
+        /// <summary>
+        /// The company name associated with a company
+        /// </summary>
+        [DataMember]
         public string Company
         {
             get { return _company; }
-            set { _company = value; }
+            set
+            {
+                SetPropertyValueAndDetectChanges(o =>
+                {
+                    _company = value;
+                    return _company;
+                }, _company, CompanySelector);
+            }
         }
 
+        /// <summary>
+        /// The address type indicator
+        /// </summary>
+        [DataMember]
         public Guid AddressTypeFieldKey
         {
             get { return _addressTypeFieldKey; }
-            set { _addressTypeFieldKey = value; }
+            set 
+            {
+                SetPropertyValueAndDetectChanges(o =>
+                {
+                    _addressTypeFieldKey = value;
+                    return _addressTypeFieldKey;
+                }, _addressTypeFieldKey, AddressTypeFieldSelector);
+            }
         }
 
+        /// <summary>
+        /// The first address line
+        /// </summary>
+        [DataMember]
         public string Address1
         {
             get { return _address1; }
-            set { _address1 = value; }
+            set
+            {
+                SetPropertyValueAndDetectChanges(o =>
+                {
+                    _address1 = value;
+                    return _address1;
+                }, _address1, Address1Selector);
+            }
         }
 
+        /// <summary>
+        /// The second address line 
+        /// </summary>
+        [DataMember]
         public string Address2
         {
             get { return _address2; }
-            set { _address2 = value; }
+            set
+            {
+                SetPropertyValueAndDetectChanges(o =>
+                {
+                    _address2 = value;
+                    return _address2;
+                }, _address2, Address2Selector);
+            }
         }
 
+        /// <summary>
+        /// The locality or city of the address
+        /// </summary>
+        [DataMember]
         public string Locality
         {
             get { return _locality; }
-            set { _locality = value; }
+            set
+            {
+                SetPropertyValueAndDetectChanges(o =>
+                {
+                    _locality = value;
+                    return _locality;
+                }, _locality, LocalitySelector);
+            }
         }
 
+        /// <summary>
+        /// The region, state or province of the address
+        /// </summary>
+        [DataMember]
         public string Region
         {
             get { return _region; }
-            set { _region = value; }
+            set
+            {
+                SetPropertyValueAndDetectChanges(o =>
+                {
+                    _region = value;
+                    return _region;
+                }, _region, RegionSelector);
+            }
         }
 
+        /// <summary>
+        /// The postal code of the address
+        /// </summary>
+        [DataMember]
         public string PostalCode
         {
             get { return _postalCode; }
-            set { _postalCode = value; }
+            set
+            {
+                SetPropertyValueAndDetectChanges(o =>
+                {
+                    _postalCode = value;
+                    return _postalCode;
+                }, _postalCode, PostalCodeSelector);
+            }
         }
 
+        /// <summary>
+        /// The country code of the address
+        /// </summary>
+        [DataMember]
         public string CountryCode
         {
             get { return _countryCode; }
-            set { _countryCode = value; }
+            set
+            {
+                {
+                    SetPropertyValueAndDetectChanges(o =>
+                    {
+                        _countryCode = value;
+                        return _countryCode;
+                    }, _countryCode, CountryCodeSelector);
+                }
+            }
         }
 
+        /// <summary>
+        /// The phone number associated with the address
+        /// </summary>
+        /// <remarks>
+        /// This is sometimes required by shipping providers
+        /// </remarks>
+        [DataMember]
         public string Phone
         {
             get { return _phone; }
-            set { _phone = value; }
+            set
+            {
+                {
+                    SetPropertyValueAndDetectChanges(o =>
+                    {
+                        _phone = value;
+                        return _phone;
+                    }, _phone, PhoneSelector);
+                }
+            }
         }
 
-        #region Strongly-typed properties
-
-        #endregion
-
-
-        /// <summary>
-        /// Method to call when EntityEntity is being saved
-        /// </summary>
-        /// <remarks>Created date is set and a Unique key is assigned</remarks>
-        internal override void AddingEntity()
-        {
-            base.AddingEntity();
-
-            if (Key == Guid.Empty)
-                Key = Guid.NewGuid();
-        }
 
 
     }
+
 }

--- a/src/Merchello.Core/Models/IAddress.cs
+++ b/src/Merchello.Core/Models/IAddress.cs
@@ -7,20 +7,14 @@ namespace Merchello.Core.Models
     /// <summary>
     /// Defines a Merchello customer
     /// </summary>
-    public interface IAddress : IKeyEntity
+    public interface IAddress : IIdEntity
     {
-
-        /// <summary>
-        /// The Address Id
-        /// </summary>
-        [DataMember]
-        int Id { get; set; }
 
         /// <summary>
         /// The Customer primary key Guid
         /// </summary>
         [DataMember]
-        Guid CustomerPk { get; set; }
+        Guid CustomerPk { get; }
 
         /// <summary>
         /// The descriptive label for the address

--- a/src/Merchello.Core/Persistence/Factories/AddressFactory.cs
+++ b/src/Merchello.Core/Persistence/Factories/AddressFactory.cs
@@ -9,11 +9,20 @@ namespace Merchello.Core.Persistence.Factories
 
         public IAddress BuildEntity(AddressDto dto)
         {
-            var address = new Address(dto.Id, dto.CustomerPk, dto.Label)
+            var address = new Address(dto.CustomerPk)
             {
                 Id = dto.Id, 
-                CustomerPk = dto.CustomerPk, 
                 Label = dto.Label,
+                FullName = dto.FullName,
+                Company =  dto.Company,
+                AddressTypeFieldKey = dto.AddressTypeFieldKey,
+                Address1 = dto.Address1,
+                Address2 = dto.Address2,
+                Locality = dto.Locality,
+                Region = dto.Region,
+                PostalCode = dto.PostalCode,
+                CountryCode = dto.CountryCode,
+                Phone = dto.Phone,
                 CreateDate = dto.CreateDate,
                 UpdateDate = dto.UpdateDate
             };

--- a/src/Merchello.Core/Persistence/Repositories/AddressRepository.cs
+++ b/src/Merchello.Core/Persistence/Repositories/AddressRepository.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using Merchello.Core.Models;
+using Merchello.Core.Models.EntityBase;
 using Merchello.Core.Models.Rdbms;
 using Merchello.Core.Persistence.Caching;
 using Merchello.Core.Persistence.Factories;
@@ -13,7 +14,7 @@ using Umbraco.Core.Persistence.UnitOfWork;
 
 namespace Merchello.Core.Persistence.Repositories
 {
-    internal class AddressRepository : MerchelloPetaPocoRepositoryBase<Guid, IAddress>, IAddressRepository
+    internal class AddressRepository : MerchelloPetaPocoRepositoryBase<int, IAddress>, IAddressRepository
     {
 
         public AddressRepository(IDatabaseUnitOfWork work)
@@ -30,7 +31,7 @@ namespace Merchello.Core.Persistence.Repositories
         #region Overrides of RepositoryBase<IAddress>
 
 
-        protected override IAddress PerformGet(Guid id)
+        protected override IAddress PerformGet(int id)
         {
             var sql = GetBaseQuery(false)
                 .Where(GetBaseWhereClause(), new { Id = id });
@@ -47,7 +48,7 @@ namespace Merchello.Core.Persistence.Repositories
             return address;
         }
 
-        protected override IEnumerable<IAddress> PerformGetAll(params Guid[] ids)
+        protected override IEnumerable<IAddress> PerformGetAll(params int[] ids)
         {
             if (ids.Any())
             {
@@ -97,7 +98,7 @@ namespace Merchello.Core.Persistence.Repositories
 
         protected override void PersistNewItem(IAddress entity)
         {
-            ((Address)entity).AddingEntity();
+            ((IdEntity)entity).AddingEntity();
 
             var factory = new AddressFactory();
             var dto = factory.BuildDto(entity);
@@ -109,7 +110,7 @@ namespace Merchello.Core.Persistence.Repositories
 
         protected override void PersistUpdatedItem(IAddress entity)
         {
-            ((Address)entity).UpdatingEntity();
+            ((IdEntity)entity).UpdatingEntity();
 
             var factory = new AddressFactory();
             var dto = factory.BuildDto(entity);
@@ -124,7 +125,7 @@ namespace Merchello.Core.Persistence.Repositories
             var deletes = GetDeleteClauses();
             foreach (var delete in deletes)
             {
-                Database.Execute(delete, new { Id = entity.Key });
+                Database.Execute(delete, new { Id = entity.Id });
             }
         }
 
@@ -137,7 +138,7 @@ namespace Merchello.Core.Persistence.Repositories
 
             var dtos = Database.Fetch<AddressDto>(sql);
 
-            return dtos.DistinctBy(x => x.Id).Select(dto => Get(dto.Id.ToGuid()));
+            return dtos.DistinctBy(x => x.Id).Select(dto => Get(dto.Id));
 
         }
 

--- a/src/Merchello.Core/Persistence/Repositories/IAddressRepository.cs
+++ b/src/Merchello.Core/Persistence/Repositories/IAddressRepository.cs
@@ -5,9 +5,9 @@ using Umbraco.Core.Persistence.Repositories;
 namespace Merchello.Core.Persistence.Repositories
 {
     /// <summary>
-    /// Marker interface for customer repositories
+    /// Marker interface for the address repository
     /// </summary>
-    public interface IAddressRepository : IRepository<Guid, IAddress>
+    public interface IAddressRepository : IRepository<int, IAddress>
     {
     }
 }

--- a/src/Merchello.Core/Persistence/Repositories/ICustomerRepository.cs
+++ b/src/Merchello.Core/Persistence/Repositories/ICustomerRepository.cs
@@ -5,7 +5,7 @@ using Umbraco.Core.Persistence.Repositories;
 namespace Merchello.Core.Persistence.Repositories
 {
     /// <summary>
-    /// Marker interface for customer repositories
+    /// Marker Interface for the customer repository
     /// </summary>
     public interface ICustomerRepository : IRepository<Guid, ICustomer>
     {

--- a/src/Merchello.Core/Persistence/RepositoryFactory.cs
+++ b/src/Merchello.Core/Persistence/RepositoryFactory.cs
@@ -18,7 +18,7 @@ namespace Merchello.Core.Persistence
 
         public virtual IAddressRepository CreateAddressRepository(IDatabaseUnitOfWork uow)
         {
-            return new AddressRepository(uow, RuntimeCacheProvider.Current);
+            return new AddressRepository(uow, NullCacheProvider.Current);
         }
     }
 }

--- a/src/Merchello.Core/Services/AddressService.cs
+++ b/src/Merchello.Core/Services/AddressService.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using Merchello.Core.Models;
+using Merchello.Core.Models.TypeFields;
 using Merchello.Core.Persistence;
 using Merchello.Core.Events;
 using Umbraco.Core;
@@ -42,18 +43,19 @@ namespace Merchello.Core.Services
         /// <summary>
         /// Creates an <see cref="IAddress"/> object
         /// </summary>
-        /// <param name="id">id value of the Address</param>
-        /// <param name="customerPk">Guid value for the customer object to which the Address belongs</param>
-        /// <param name="label">Descriptive name for the Address</param>
-        /// <returns></returns>
-        public IAddress CreateAddress(int id, Guid customerPk, string label)
+        public IAddress CreateAddress(Guid customerPk, string label, ITypeField addressType, string address1, string address2, string locality, string region, string postalCode, string countryCode)
         {
-            var address = new Address(0, new Guid(), null)
-            {
-                Id = id, 
-                CustomerPk = customerPk, 
-                Label = label
-            };
+            var address = new Address(customerPk)
+                {
+                    Label = label,
+                    AddressTypeFieldKey = addressType.TypeKey,
+                    Address1 = address1,
+                    Address2 = address2,
+                    Locality = locality,
+                    Region = region,
+                    PostalCode = postalCode,
+                    CountryCode = countryCode
+                };
 
             Created.RaiseEvent(new NewEventArgs<IAddress>(address), this);
 
@@ -162,11 +164,11 @@ namespace Merchello.Core.Services
         /// </summary>
         /// <param name="id">int Id for the Address</param>
         /// <returns><see cref="IAddress"/></returns>
-        public IAddress GetByKey(int id)
+        public IAddress GetById(int id)
         {
             using (var repository = _repositoryFactory.CreateAddressRepository(_uowProvider.GetUnitOfWork()))
             {
-                return repository.Get(id.ToGuid());
+                return repository.Get(id);
             }
         }
 
@@ -175,11 +177,11 @@ namespace Merchello.Core.Services
         /// </summary>
         /// <param name="keys">List of unique keys</param>
         /// <returns></returns>
-        public IEnumerable<IAddress> GetByKeys(IEnumerable<Guid> keys)
+        public IEnumerable<IAddress> GetByIds(IEnumerable<int> ids)
         {
             using (var repository = _repositoryFactory.CreateAddressRepository(_uowProvider.GetUnitOfWork()))
             {
-                return repository.GetAll(keys.ToArray());
+                return repository.GetAll(ids.ToArray());
             }
         }
 
@@ -238,5 +240,7 @@ namespace Merchello.Core.Services
 
         #endregion
 
+
+     
     }
 }

--- a/src/Merchello.Core/Services/IAddressService.cs
+++ b/src/Merchello.Core/Services/IAddressService.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using Merchello.Core.Models;
+using Merchello.Core.Models.TypeFields;
 using Umbraco.Core.Services;
 
 namespace Merchello.Core.Services
@@ -13,14 +14,11 @@ namespace Merchello.Core.Services
     /// </summary>
     public interface IAddressService : IService
     {
+
         /// <summary>
         /// Creates a Address
         /// </summary>
-        /// <param name="id"></param>
-        /// <param name="customerPk"></param>
-        /// <param name="label"></param>
-        /// <returns><see cref="IAddress"/></returns>
-        IAddress CreateAddress(int id, Guid customerPk, string label);
+        IAddress CreateAddress(Guid customerPk, string label, ITypeField addressType, string address1, string address2, string locality, string region, string postalCode, string countryCode);
 
         /// <summary>
         /// Saves a single <see cref="IAddress"/> object
@@ -55,14 +53,14 @@ namespace Merchello.Core.Services
         /// </summary>
         /// <param name="id">int Id of the Address to retrieve</param>
         /// <returns><see cref="IAddress"/></returns>
-        IAddress GetByKey(int id);
+        IAddress GetById(int id);
 
         /// <summary>
         /// Gets list of <see cref="IAddress"/> objects given a list of Unique keys
         /// </summary>
-        /// <param name="keys">List of Guid pk for Addresss to retrieve</param>
+        /// <param name="ids">List of int Id for Addresss to retrieve</param>
         /// <returns>List of <see cref="IAddress"/></returns>
-        IEnumerable<IAddress> GetByKeys(IEnumerable<Guid> keys);
+        IEnumerable<IAddress> GetByIds(IEnumerable<int> ids);
 
     }
 }

--- a/test/Merchello.Tests.Base/Data/AddressData.cs
+++ b/test/Merchello.Tests.Base/Data/AddressData.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using Merchello.Core.Models;
+using Merchello.Core.Models.TypeFields;
 
 namespace Merchello.Tests.Base.Data
 {
@@ -12,22 +13,29 @@ namespace Merchello.Tests.Base.Data
 
         public static IAddress AddressForInserting()
         {
-            var address = new Address(0, new Guid(), string.Empty)
-            {
-                Id = 0, 
-                CustomerPk = new Guid(), 
-                Label = "Billing"
-            };
+            // this won't work for integration tests because of the database constraint.
+
+            var address = new Address(Guid.NewGuid())
+                {
+                    Label = "Home",
+                    Address1 = "111 Somewhere",
+                    AddressTypeFieldKey = AddressTypeField.Residential.TypeKey,
+                    Company = "Demo Co.",
+                    Locality = "Seattle",
+                    Region = "WA",
+                    PostalCode = "99701",
+                    CountryCode = "US"
+                };
 
             address.ResetDirtyProperties();
 
             return address;
+            
         }
 
         public static IAddress AddressForUpdating()
         {
             var address = AddressData.AddressForInserting();
-            address.Id = 0;
             address.ResetDirtyProperties();
             return address;
 
@@ -37,24 +45,38 @@ namespace Merchello.Tests.Base.Data
         {
             return new List<IAddress>()
                 {
-                    new Address(0, new Guid(), null)
-                        {
-                            Id = 0, 
-                            CustomerPk = new Guid(), 
-                            Label = "Billing"
-                        },
-                    new Address(0, new Guid(), null)
-                        {
-                            Id = 0, 
-                            CustomerPk = new Guid(), 
-                            Label = "Shipping"
-                        },
-                     new Address(0, new Guid(), null)
-                        {
-                            Id = 0, 
-                            CustomerPk = new Guid(), 
-                            Label = "Summer Cabin"
-                        }
+                   new Address(Guid.NewGuid())
+                    {
+                        Label = "Home",
+                        Address1 = "111 Somewhere",
+                        AddressTypeFieldKey = AddressTypeField.Residential.TypeKey,
+                        Company = "Demo Co.",
+                        Locality = "Seattle",
+                        Region = "WA",
+                        PostalCode = "99701",
+                        CountryCode = "US"
+                    },
+                    new Address(Guid.NewGuid())
+                    {
+                        Label = "Viva",
+                        Address1 = "666 Drifters Highway",
+                        AddressTypeFieldKey = AddressTypeField.Commercial.TypeKey,
+                        Company = "Vegas.",
+                        Locality = "Las Vegas",
+                        Region = "NV",
+                        PostalCode = "00122",
+                        CountryCode = "US"
+                    },
+                    new Address(Guid.NewGuid())
+                    {
+                        Label = "Condo",
+                        Address1 = "12 Hampton Ct.",
+                        AddressTypeFieldKey = AddressTypeField.Residential.TypeKey,
+                        Locality = "District of Columbia",
+                        Region = "DC",
+                        PostalCode = "11111",
+                        CountryCode = "US"
+                    }
 
                 };
 

--- a/test/Merchello.Tests.IntegrationTests/Services/AddressServiceTests.cs
+++ b/test/Merchello.Tests.IntegrationTests/Services/AddressServiceTests.cs
@@ -21,7 +21,7 @@ namespace Merchello.Tests.IntegrationTests.Services
 
             var service = new AddressService();
 
-            var address = service.GetByKey(0);
+            var address = service.GetById(0);
 
             var addresses = service.GetAll();
 

--- a/test/Merchello.Tests.UnitTests/Services/AddressServiceTests.cs
+++ b/test/Merchello.Tests.UnitTests/Services/AddressServiceTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using Merchello.Core.Models;
+using Merchello.Core.Models.TypeFields;
 using Merchello.Tests.Base.Data;
 using Merchello.Tests.Base.Services;
 using NUnit.Framework;
@@ -13,7 +14,7 @@ namespace Merchello.Tests.UnitTests.Services
         [Test]
         public void Create_Triggers_Event_Assert_And_Address_Is_Passed()
         {
-            var address = AddressService.CreateAddress(0, new Guid(), "Home");
+            var address = AddressService.CreateAddress(new Guid(), "Billing", AddressTypeField.Residential, "111 somewhere", string.Empty, "Somewhere", "Outthere", "11111", "US");
 
             Assert.IsTrue(AfterTriggered);
         }


### PR DESCRIPTION
Initial implementation incorrectly used Guid keys for primary keys on the Address object.

This commit corrects the repository and services to use the the int Id primary key, refactors the Address object a bit and updates the unit tests covering the Address.
