### PR TITLE
Shipping models

### DIFF
--- a/src/Merchello.Web.UI/App_Plugins/Merchello/Modules/Settings/shipping.models.js
+++ b/src/Merchello.Web.UI/App_Plugins/Merchello/Modules/Settings/shipping.models.js
@@ -16,6 +16,23 @@
             });
         }
 
+
+        // Helper to add a new shipping method to the country.
+        self.addBlankShippingMethod = function () {
+
+            var newShippingMethod = new merchello.Models.ShippingMethod();
+
+            self.shippingMethods.push(newShippingMethod);
+
+        };
+
+        // Helper to remove a shipping method from a country.
+        self.removeShippingMethod = function (idx) {
+
+            self.shippingMethods.splice(idx, 1);
+
+        };
+
     };
 
     models.ShippingMethod = function (shippingMethodFromServer) {
@@ -43,6 +60,25 @@
                 return new merchello.Models.ShippingRegion(attribute);
             });
         }
+
+
+        // Helper to add a shipping region adjustment to this shipping method.
+        self.addShippingRegion = function (properties) {
+
+            var newShippingRegion = new merchello.Models.ShippingRegion();
+
+            // Note From Kyle: Not sure what preferred method we have on this project to inject the properties (if any) into the newly created region.
+            
+            self.shippingRegions.push(newShippingRegion);
+
+        };
+
+        // Helper to remove a shipping region adjustment from this shipping method.
+        self.removeShippingRegion = function (idx) {
+
+            self.shippingRegions.splice(idx, 1);
+
+        };
 
     };
 

--- a/src/Merchello.Web.UI/App_Plugins/Merchello/Package.manifest
+++ b/src/Merchello.Web.UI/App_Plugins/Merchello/Package.manifest
@@ -33,6 +33,7 @@
 		'~/App_Plugins/Merchello/Modules/Report/reports.salesByItem.controller.js',
 		'~/App_Plugins/Merchello/Modules/Report/reports.salesOverTime.controller.js',
 		'~/App_Plugins/Merchello/Modules/Report/reports.taxesByDestination.controller.js',
+		'~/App_Plugins/Merchello/Modules/Settings/shipping.models.js',
 		'~/App_Plugins/Merchello/Modules/Settings/settings.controller.js',
 		'~/App_Plugins/Merchello/Modules/Settings/debug.controller.js',
 		'~/App_Plugins/Merchello/Modules/Settings/payment.controller.js',


### PR DESCRIPTION
Started shipping.models.js, added to package.manifest, outlined the models for the Shipping settings page, but still working on associated methods.
