### PR TITLE
Patches the line item mapping issue

### DIFF
--- a/src/Merchello.Core/Builders/BuildChainBase.cs
+++ b/src/Merchello.Core/Builders/BuildChainBase.cs
@@ -49,7 +49,9 @@ namespace Merchello.Core.Builders
         /// <returns><see cref="Attempt"/> of T</returns>
         public abstract Attempt<T> Build();
 
-
+        /// <summary>
+        /// Defines the arguements required for task instantiation
+        /// </summary>
         protected abstract Tuple<Type[], object[]> ConstructorParameters { get; } 
 
         /// <summary>

--- a/src/Merchello.Core/Builders/InvoiceBuilderChain.cs
+++ b/src/Merchello.Core/Builders/InvoiceBuilderChain.cs
@@ -6,6 +6,9 @@ using Umbraco.Core;
 
 namespace Merchello.Core.Builders
 {
+    /// <summary>
+    /// Represents an invoice builder
+    /// </summary>
     internal sealed class InvoiceBuilderChain : BuildChainBase<IInvoice>
     {
         private readonly CheckoutBase _checkout;

--- a/src/Merchello.Core/Builders/TaxationQuoteBuilderChain.cs
+++ b/src/Merchello.Core/Builders/TaxationQuoteBuilderChain.cs
@@ -1,11 +1,12 @@
 ﻿using System;
+using System.Linq;
 using Merchello.Core.Models;
 using Umbraco.Core;
 
 namespace Merchello.Core.Builders
 {
     /// <summary>
-    /// Represents the 
+    /// Represents the taxation quote builder
     /// </summary>
     internal sealed class TaxationQuoteBuilderChain : BuildChainBase<IInvoice>
     {
@@ -23,6 +24,14 @@ namespace Merchello.Core.Builders
         protected override Tuple<Type[], object[]> ConstructorParameters
         {
             get { throw new NotImplementedException(); }
+        }
+
+        /// <summary>
+        /// Used for testing
+        /// </summary>
+        internal int TaskCount
+        {
+            get { return TaskHandlers.Count(); }
         }
     }
 }

--- a/src/Merchello.Core/Chains/CheckOut/AddShipmentLineItemsToInvoiceTask.cs
+++ b/src/Merchello.Core/Chains/CheckOut/AddShipmentLineItemsToInvoiceTask.cs
@@ -18,6 +18,7 @@ namespace Merchello.Core.Chains.CheckOut
         /// <returns></returns>
         public override Attempt<IInvoice> PerformTask(IInvoice value)
         {
+
             return Attempt<IInvoice>.Succeed(value);
         }
     }

--- a/src/Merchello.Core/Chains/CheckOut/ApplyTaxesToInvoiceTax.cs
+++ b/src/Merchello.Core/Chains/CheckOut/ApplyTaxesToInvoiceTax.cs
@@ -12,6 +12,9 @@ namespace Merchello.Core.Chains.CheckOut
 
         public override Attempt<IInvoice> PerformTask(IInvoice value)
         {
+            // if taxes are not to be applied, skip this step
+            if(!Checkout.ApplyTaxesToInvoice) return Attempt<IInvoice>.Succeed(value);
+
             return Attempt<IInvoice>.Succeed(value);
         }
     }

--- a/src/Merchello.Core/Chains/InvoiceTaxRateQuote/IdentifyTaxableLineItems.cs
+++ b/src/Merchello.Core/Chains/InvoiceTaxRateQuote/IdentifyTaxableLineItems.cs
@@ -7,6 +7,7 @@ namespace Merchello.Core.Chains.InvoiceTaxRateQuote
 {
     internal class IdentifyTaxableLineItems : AttemptChainTaskBase<IInvoice>
     {
+
         public override Attempt<IInvoice> PerformTask(IInvoice value)
         {
             throw new System.NotImplementedException();

--- a/src/Merchello.Core/Chains/InvoiceTaxRateQuote/InvoiceTaxRateQuoteBase.cs
+++ b/src/Merchello.Core/Chains/InvoiceTaxRateQuote/InvoiceTaxRateQuoteBase.cs
@@ -6,5 +6,19 @@ namespace Merchello.Core.Chains.InvoiceTaxRateQuote
     {
         private readonly IInvoice _invoice;
 
+        protected InvoiceTaxRateQuoteBase(IInvoice invoice)
+        {
+            Mandate.ParameterNotNull(invoice, "invoice");
+
+            _invoice = invoice;
+        }
+
+        /// <summary>
+        /// Gets the <see cref="IInvoice"/>
+        /// </summary>
+        protected IInvoice Invoice
+        {
+            get { return _invoice; }
+        }
     }
 }

--- a/src/Merchello.Core/Checkout/CheckoutBase.cs
+++ b/src/Merchello.Core/Checkout/CheckoutBase.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using Merchello.Core.Gateways.Payment;
 using Merchello.Core.Gateways.Shipping;
 using Merchello.Core.Models;
 using Merchello.Core.Services;
@@ -73,19 +72,13 @@ namespace Merchello.Core.Checkout
             MerchelloContext.Services.ItemCacheService.Save(_itemCache);
         }
 
+        /// <summary>
+        /// Maps the <see cref="IShipmentRateQuote"/> to a <see cref="ILineItem"/> 
+        /// </summary>
+        /// <param name="shipmentRateQuote">The <see cref="IShipmentRateQuote"/> to be added as a <see cref="ILineItem"/></param>
         private void AddShipmentRateQuoteLineItem(IShipmentRateQuote shipmentRateQuote)
         {
-            var shipment = shipmentRateQuote.Shipment;
-            var shipmentName = string.Format("Shipment - {0} - {1} items", shipmentRateQuote.ShipMethod.Name, shipment.Items.Count);
-
-            var extentedData = new ExtendedDataCollection();
-            extentedData.AddShipment(shipment);
-
-            var item = new ItemCacheLineItem(LineItemType.Shipping, shipmentName, Guid.NewGuid().ToString(), 1, shipmentRateQuote.Rate, extentedData)
-                {
-                    ContainerKey = _itemCache.Key
-                };
-            _itemCache.AddItem(item);
+            _itemCache.AddItem(shipmentRateQuote.AsLineItemOf<ItemCacheLineItem>());
         }
 
         ///// <summary>
@@ -162,5 +155,7 @@ namespace Merchello.Core.Checkout
         {
             get { return _itemCache; }
         }
+
+        public bool ApplyTaxesToInvoice { get; set; }
     }
 }

--- a/src/Merchello.Core/Checkout/ICheckoutBase.cs
+++ b/src/Merchello.Core/Checkout/ICheckoutBase.cs
@@ -39,6 +39,9 @@ namespace Merchello.Core.Checkout
         /// </remarks>
         void SaveShipmentRateQuote(IEnumerable<IShipmentRateQuote> approvedShipmentRateQuotes);
 
+
+        bool ApplyTaxesToInvoice { get; set; }
+
         ///// <summary>
         ///// Generates an <see cref="IInvoice"/> representing the bill for the current "checkout order"
         ///// </summary>

--- a/src/Merchello.Core/Gateways/Taxation/CountryTaxRate/CountryTaxRateInvoiceQuoteStrategy.cs
+++ b/src/Merchello.Core/Gateways/Taxation/CountryTaxRate/CountryTaxRateInvoiceQuoteStrategy.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using Merchello.Core.Configuration;
 using Merchello.Core.Models;
 using Umbraco.Core;
 
@@ -16,12 +17,16 @@ namespace Merchello.Core.Gateways.Taxation.CountryTaxRate
             _countryTaxRate = countryTaxRate;
         }
 
+
+
         /// <summary>
         /// Computes the invoice tax result
         /// </summary>
         /// <returns>The <see cref="IInvoiceTaxResult"/></returns>
         public override Attempt<IInvoiceTaxResult> GetInvoiceTaxResult()
         {
+            // instantiate the task chain
+            
             throw new NotImplementedException();
         }
     }

--- a/src/Merchello.Core/Gateways/Taxation/CountryTaxRate/CountryTaxRateTaxationGatewayProvider.cs
+++ b/src/Merchello.Core/Gateways/Taxation/CountryTaxRate/CountryTaxRateTaxationGatewayProvider.cs
@@ -95,7 +95,6 @@ namespace Merchello.Core.Gateways.Taxation.CountryTaxRate
             return CalculateTaxForInvoice(strategy);
         }
 
-
         public override string Name
         {
             get { return "Fixed Rate Tax Provider"; }

--- a/src/Merchello.Core/Models/LineItemExtensions.cs
+++ b/src/Merchello.Core/Models/LineItemExtensions.cs
@@ -61,7 +61,7 @@ namespace Merchello.Core.Models
         /// <typeparam name="T"></typeparam>
         /// <param name="lineItem"></param>
         /// <returns>A <see cref="LineItemBase"/> of type T</returns>
-        public static T ConvertToNewLineItemOf<T>(this ILineItem lineItem) where T : LineItemBase
+        public static T ConvertToNewLineItemOf<T>(this ILineItem lineItem) where T : class, ILineItem
         {    
             var ctrValues = new object[]
                 {                    
@@ -86,22 +86,24 @@ namespace Merchello.Core.Models
         /// <typeparam name="T">The type of the line item to create</typeparam>
         /// <param name="shipmentRateQuote">The <see cref="ShipmentRateQuote"/> to be translated to a line item</param>
         /// <returns>A <see cref="LineItemBase"/> of type T</returns>
-        public static ILineItem AsLineItemOf<T>(this IShipmentRateQuote shipmentRateQuote) where T : LineItemBase
+        public static T AsLineItemOf<T>(this IShipmentRateQuote shipmentRateQuote) where T : LineItemBase
         {
             var extendedData = new ExtendedDataCollection();
             extendedData.AddShipment(shipmentRateQuote.Shipment);
 
+            var shipmentName = string.Format("Shipment - {0} - {1} items", shipmentRateQuote.ShipMethod.Name, shipmentRateQuote.Shipment.Items.Count);
+            
             var ctrValues = new object[]
                 {
                     EnumTypeFieldConverter.LineItemType.Shipping.TypeKey,
-                    shipmentRateQuote.ShipMethod.Name,
-                    shipmentRateQuote.ShipMethod.ServiceCode, // TODO this may not be unique once multiple shipments are exposed
+                    shipmentName,
+                    shipmentRateQuote.ShipMethod.ServiceCode, // TODO this may not be unique (SKU) once multiple shipments are exposed
                     1,
                     shipmentRateQuote.Rate,
                     extendedData
                 };
 
-            return ActivatorHelper.CreateInstance<LineItemBase>(typeof (T), LineItemConstructorArgs, ctrValues);
+            return ActivatorHelper.CreateInstance<LineItemBase>(typeof (T), LineItemConstructorArgs, ctrValues) as T;
         }
 
 

--- a/src/Merchello.Core/Persistence/Repositories/LineItemRepository.cs
+++ b/src/Merchello.Core/Persistence/Repositories/LineItemRepository.cs
@@ -239,6 +239,10 @@ namespace Merchello.Core.Persistence.Repositories
 
             foreach (var item in lineItems)
             {
+                // In the mapping between different line item types the container key is 
+                // invalidated so we need to set it to the current container.
+                if (!item.ContainerKey.Equals(containerKey)) item.ContainerKey = containerKey;
+
                 SaveLineItem(item);
             }
         }

--- a/test/Merchello.Tests.IntegrationTests/A.DbInstall/DatabaseSchema.cs
+++ b/test/Merchello.Tests.IntegrationTests/A.DbInstall/DatabaseSchema.cs
@@ -6,7 +6,7 @@ using Merchello.Tests.IntegrationTests.TestHelpers;
 using NUnit.Framework;
 using Umbraco.Core.Persistence;
 
-namespace Merchello.Tests.IntegrationTests.DbInstall
+namespace Merchello.Tests.IntegrationTests.A.DbInstall
 {
     [TestFixture]
     public class DatabaseSchema

--- a/test/Merchello.Tests.IntegrationTests/A.DbInstall/InitialDataTests.cs
+++ b/test/Merchello.Tests.IntegrationTests/A.DbInstall/InitialDataTests.cs
@@ -5,7 +5,7 @@ using Merchello.Tests.IntegrationTests.TestHelpers;
 using NUnit.Framework;
 using Umbraco.Core.Persistence;
 
-namespace Merchello.Tests.IntegrationTests.DbInstall
+namespace Merchello.Tests.IntegrationTests.A.DbInstall
 {
     [TestFixture]
     public class InitialDataTests

--- a/test/Merchello.Tests.IntegrationTests/App.config
+++ b/test/Merchello.Tests.IntegrationTests/App.config
@@ -170,7 +170,7 @@
           </taskChain>
           <taskChain alias="InvoiceTaxRateQuote">
               <tasks>
-                  
+                  <task type="Merchello.Core.Chains.InvoiceTaxRateQuote.IdentifyTaxableLineItems, Merchello.Core" />
               </tasks>
           </taskChain>
       </taskChains>

--- a/test/Merchello.Tests.IntegrationTests/Builders/BuilderTestBase.cs
+++ b/test/Merchello.Tests.IntegrationTests/Builders/BuilderTestBase.cs
@@ -1,0 +1,27 @@
+﻿using Merchello.Core;
+using Merchello.Core.Cache;
+using Merchello.Core.Persistence.UnitOfWork;
+using Merchello.Core.Services;
+using Merchello.Tests.IntegrationTests.TestHelpers;
+using NUnit.Framework;
+using Umbraco.Core;
+
+namespace Merchello.Tests.IntegrationTests.Builders
+{
+    public class BuilderTestBase : DatabaseIntegrationTestBase
+    {
+        [TestFixtureSetUp]
+        public override void FixtureSetup()
+        {
+            base.FixtureSetup();
+
+            MerchelloContext = new MerchelloContext(new ServiceContext(new PetaPocoUnitOfWorkProvider()),
+                new CacheHelper(new NullCacheProvider(),
+                    new NullCacheProvider(),
+                    new NullCacheProvider()));
+
+        }
+
+        protected IMerchelloContext MerchelloContext { get; private set; }
+    }
+}

--- a/test/Merchello.Tests.IntegrationTests/Builders/TaxationQuoteBuilderTests.cs
+++ b/test/Merchello.Tests.IntegrationTests/Builders/TaxationQuoteBuilderTests.cs
@@ -1,0 +1,102 @@
+﻿using System;
+using System.Linq;
+using Merchello.Core;
+using Merchello.Core.Builders;
+using Merchello.Core.Checkout;
+using Merchello.Core.Gateways.Shipping;
+using Merchello.Core.Models;
+using Merchello.Tests.Base.DataMakers;
+using Merchello.Web;
+using Merchello.Web.Workflow;
+using NUnit.Framework;
+
+namespace Merchello.Tests.IntegrationTests.Builders
+{
+    [TestFixture]
+    [Category("Builders")]
+    public class TaxationQuoteBuilderTests : BuilderTestBase
+    {
+        private IItemCache _itemCache;
+        private ICustomerBase _customer;
+        private IBasket _basket;
+        private IAddress _billingAddress;
+        private IAddress _originAddress;
+        private CheckoutBase _checkoutMock;
+        private const decimal ProductCount = 5;
+        private const decimal WeightPerProduct = 3;
+        private const decimal PricePerProduct = 5;
+
+        [TestFixtureSetUp]
+        public override void FixtureSetup()
+         {
+             base.FixtureSetup();
+
+             _customer = PreTestDataWorker.MakeExistingAnonymousCustomer();
+             _basket = Basket.GetBasket(MerchelloContext, _customer);
+             for (var i = 0; i < ProductCount; i++) _basket.AddItem(PreTestDataWorker.MakeExistingProduct(true, WeightPerProduct, PricePerProduct));
+
+             _billingAddress = new Address()
+             {
+                 Name = "Out there",
+                 Address1 = "some street",
+                 Locality = "some city",
+                 Region = "ST",
+                 PostalCode = "98225",
+                 CountryCode = "US"
+             };
+
+             _originAddress = new Address()
+             {
+                 Name = "Somewhere",
+                 Address1 = "origin street",
+                 Locality = "origin city",
+                 Region = "ST",
+                 PostalCode = "98225",
+                 CountryCode = "US"
+             };
+
+             _customer.ExtendedData.AddAddress(_billingAddress, AddressType.Billing);             
+
+         }
+
+        [SetUp]
+        public void Init()
+        {
+            _itemCache = new Core.Models.ItemCache(_customer.EntityKey, ItemCacheType.Checkout);
+
+
+            // setup the checkout
+            _checkoutMock = new CheckoutMock(MerchelloContext, _itemCache, _customer);
+
+            // add the shipment rate quote
+            var shipment = _basket.PackageBasket(MerchelloContext, _billingAddress).First();
+            var shipRateQuote = new ShipmentRateQuote(shipment, new ShipMethod(Guid.NewGuid(), Guid.NewGuid())
+            {
+                Name = "Unit test rate quote",
+                ServiceCode = "Test1"
+            })
+            {
+                Rate = 5M
+            };
+
+            _checkoutMock.ItemCache.Items.Add(shipRateQuote.AsLineItemOf<InvoiceLineItem>());
+        }
+
+        ///// <summary>
+        ///// Test verifies that the builder instantiates with the number of expected tasks
+        ///// </summary>
+        //[Test]
+        //public void TaxationQuoteBuilder_Instaniates_With_Expected_Number_Of_Tasks()
+        //{
+        //    //// Arrage
+        //    const int expected = 1;
+            
+        //    //// Act
+        //    var builder = new TaxationQuoteBuilderChain();
+
+        //    //// Assert
+        //    Assert.AreEqual(expected, builder.TaskCount);
+        //}
+
+    }
+}

--- a/test/Merchello.Tests.IntegrationTests/Merchello.Tests.IntegrationTests.csproj
+++ b/test/Merchello.Tests.IntegrationTests/Merchello.Tests.IntegrationTests.csproj
@@ -232,7 +232,9 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="Invoicing\InvoiceBuilderTests.cs" />
+    <Compile Include="Builders\BuilderTestBase.cs" />
+    <Compile Include="Builders\InvoiceBuilderTests.cs" />
+    <Compile Include="Builders\TaxationQuoteBuilderTests.cs" />
     <Compile Include="DisplayClasses\ProductDisplayTests.cs" />
     <Compile Include="DisplayClasses\ShippingDisplayTests.cs" />
     <Compile Include="DisplayClasses\WarehouseDisplayTests.cs" />
@@ -242,9 +244,9 @@
     <Compile Include="Services\StoreSettings\StoreSettingsServiceTests.cs" />
     <Compile Include="Shipping\BasketPackagingTests.cs" />
     <Compile Include="ItemCache\BasketTests.cs" />
-    <Compile Include="DbInstall\InitialDataTests.cs" />
+    <Compile Include="A.DbInstall\InitialDataTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="DbInstall\DatabaseSchema.cs" />
+    <Compile Include="A.DbInstall\DatabaseSchema.cs" />
     <Compile Include="Examine\ProductProviderTests.cs" />
     <Compile Include="Services\Customer\CustomerItemCacheServiceTests.cs" />
     <Compile Include="Services\Customer\CustomerServiceTests.cs" />


### PR DESCRIPTION
Patches the line item mapping issue caused by a line item being mapped and added to a different collection by instantiating a new object of the target type and adds check in the LineItemRepository to set the key of the new parent container.
