### PR TITLE
refactoring all inventory stuff for product/variant, fixes

### DIFF
--- a/src/Merchello.Web.UI/App_Plugins/Merchello/Backoffice/Merchello/ProductVariantEdit.html
+++ b/src/Merchello.Web.UI/App_Plugins/Merchello/Backoffice/Merchello/ProductVariantEdit.html
@@ -89,7 +89,7 @@
                                     <label class="label-checkbox"><input name="taxable" type="checkbox" data-ng-model="productVariant.taxable"> <span>This variant is taxable</span></label>
                                 </div>
                                 <div class="form-group col-xs-6 span6">
-                                    <label class="label-checkbox"><input name="trackinventory" type="checkbox" data-ng-model="productVariant.trackInventory" data-ng-disabled="productVariant.hasOptions"> <span>Track inventory for this variant</span></label>
+                                    <label class="label-checkbox"><input name="trackinventory" type="checkbox" data-ng-model="productVariant.trackInventory" data-ng-disabled="productVariant.hasOptions || productVariant.hasDigitalDownload" data-ng-click="ensureCatalogInventory()"> <span>Track inventory for this variant</span></label>
                                     <label class="label-checkbox"><input name="shippable" type="checkbox" data-ng-model="productVariant.shippable"> <span>This variant is shippable</span></label>
                                 </div>
                             </div>
@@ -183,7 +183,8 @@
                                             <input class="form-control input-mini" data-ng-model="variant.barcode" />
                                         </td>
                                         <td>
-                                            <input class="form-control input-mini" data-ng-model="variant.inventory" />
+                                            <input type="checkbox" data-ng-model="variant.trackInventory" />
+                                            <input class="form-control input-mini" data-ng-show="variant.trackInventory" data-ng-model="variant.totalInventoryCount" data-ng-change="variant.globalInventoryChanged(variant.totalInventoryCount)" />
                                         </td>
                                     </tr>
                                 </table>
@@ -247,7 +248,7 @@
                                     </tr>
                                     <tr data-ng-repeat="catalogInv in productVariant.catalogInventories">
                                         <td class="span1"><input name="incatalog" type="checkbox" disabled="disabled" checked="checked"></td>
-                                        <td class="name">{{defaultWarehouse.name}}</td>
+                                        <td class="name">{{defaultWarehouse.name}} - {{defaultWarehouse.warehouseCatalogs[0].name}}</td>
                                         <td><input type="text" class="col-xs-8 span8" data-ng-model="catalogInv.count" /></td>
                                         <td><input type="text" class="col-xs-8 span8" data-ng-model="catalogInv.lowCount" /></td>
                                     </tr>

--- a/src/Merchello.Web.UI/App_Plugins/Merchello/Modules/Catalog/product.models.js
+++ b/src/Merchello.Web.UI/App_Plugins/Merchello/Modules/Catalog/product.models.js
@@ -237,7 +237,10 @@
 
             self.attributes = [];
 
-            self.catalogInventories = product.catalogInventories.slice(0);
+            for (var i = 0; i < product.catalogInventories.length; i++) {
+                self.catalogInventories.push(new merchello.Models.CatalogInventory(product.catalogInventories[i]));
+            }
+            //self.catalogInventories = product.catalogInventories.slice(0);
         };
 
         self.fixAttributeSortOrders = function (options) {
@@ -258,6 +261,38 @@
                 self[option.name] = attr.name;
             }
         };
+
+        self.ensureCatalogInventory = function(defaultWarehouse)
+        {
+            if (self.catalogInventories.length == 0)
+            {
+                self.addCatalogInventory(defaultWarehouse);
+            }
+        }
+
+        // Helper to add a variant to this product
+        self.addCatalogInventory = function (warehouse) {
+
+            var newCatalogInventory = new merchello.Models.CatalogInventory();
+            newCatalogInventory.productVariantKey = self.key;
+            newCatalogInventory.warehouseKey = warehouse.key;
+            newCatalogInventory.catalogKey = warehouse.warehouseCatalogs[0].key;
+            newCatalogInventory.catalogName = warehouse.warehouseCatalogs[0].name;
+
+            self.catalogInventories.push(newCatalogInventory);
+
+            return newCatalogInventory;
+        };
+
+        self.globalInventoryChanged = function (newVal) {
+            if (newVal)
+            {
+                for (var i = 0; i < self.catalogInventories.length; i++)
+                {
+                    self.catalogInventories[i].count = newVal;
+                }
+            }
+        }
     };
 
     models.Product = function (productFromServer, dontMapChildren) {
@@ -440,6 +475,7 @@
                 self.productVariants[i].addAttributesAsProperties(self.productOptions);
             }
         };
+
     };
 
 

--- a/src/Merchello.Web.UI/App_Plugins/Merchello/Modules/Catalog/productvariant.edit.controller.js
+++ b/src/Merchello.Web.UI/App_Plugins/Merchello/Modules/Catalog/productvariant.edit.controller.js
@@ -58,6 +58,11 @@
             });
         }
 
+        function isCreating()
+        {
+            return $routeParams.create;
+        }
+
         ////////////////////////////////////////////////
         // Initialize state
 
@@ -66,13 +71,17 @@
         promise.then(function (warehouse) {
             $scope.defaultWarehouse = new merchello.Models.Warehouse(warehouse);
             $scope.warehouses.push($scope.defaultWarehouse);
+            if (isCreating())
+            {
+                $scope.productVariant.ensureCatalogInventory($scope.defaultWarehouse);
+            }
         });
 
         $scope.settings = {};
         var promiseSettings = merchelloSettingsService.getAllSettings();
         promiseSettings.then(function (settings) {
             $scope.settings = new merchello.Models.StoreSettings(settings);
-            if ($routeParams.create) {
+            if (isCreating()) {
                 $scope.productVariant.shippable = $scope.settings.globalShippable;
                 $scope.productVariant.taxable = $scope.settings.globalTaxable;
                 $scope.productVariant.trackInventory = $scope.settings.globalTrackInventory;
@@ -80,7 +89,7 @@
         });
 
 
-        if ($routeParams.create) {
+        if (isCreating()) {
             $scope.creatingVariant = true;
             $scope.loaded = true;
             $scope.preValuesLoaded = true;
@@ -239,6 +248,11 @@
             {
                 $scope.product.addBlankOption();
             }
+        };
+
+        $scope.ensureCatalogInventory = function () {
+
+            $scope.productVariant.ensureCatalogInventory($scope.defaultWarehouse);
         };
 
         $scope.addOption = function () {

--- a/src/Merchello.Web.UI/App_Plugins/Merchello/Modules/Settings/shipping.models.js
+++ b/src/Merchello.Web.UI/App_Plugins/Merchello/Modules/Settings/shipping.models.js
@@ -185,8 +185,8 @@
             self.catalogKey = "";
             self.warehouseKey = "";
             self.productVariantKey = "";
-            self.count = "";
-            self.lowCount = "";
+            self.count = 0;
+            self.lowCount = 0;
             self.catalogName = "";
         } else {
             self.catalogKey = catalogInventoryFromServer.catalogKey;

--- a/src/Merchello.Web/Editors/ProductApiController.cs
+++ b/src/Merchello.Web/Editors/ProductApiController.cs
@@ -177,15 +177,11 @@ namespace Merchello.Web.Editors
             try
             {
                 newProduct = _productService.CreateProductWithKey(name, sku, price) as Product;
+                _productService.Save(newProduct);
 
-                if (!newProduct.Download)
-                {
-                    newProduct.AddToCatalogInventory(_warehouseService.GetDefaultWarehouse().DefaultCatalog());
-                    newProduct.CatalogInventories.First().Count = 10;
-                    _productService.Save(newProduct);
-
-                    //newProduct = _productService.GetByKey(newProduct.Key) as Product;
-                }
+                newProduct.AddToCatalogInventory(_warehouseService.GetDefaultWarehouse().DefaultCatalog());
+                newProduct.CatalogInventories.First().Count = 10;
+                _productService.Save(newProduct);
             }
             catch (Exception ex)
             {
@@ -209,17 +205,17 @@ namespace Merchello.Web.Editors
             try
             {
                 newProduct = _productService.CreateProduct(product.Name, product.Sku, product.Price);
-                newProduct = product.ToProduct(newProduct);
                 _productService.Save(newProduct);
 
-                if (!newProduct.Download)
-                {
+                //if (product.TrackInventory)
+                //{
                     newProduct.AddToCatalogInventory(_warehouseService.GetDefaultWarehouse().DefaultCatalog());
                     newProduct.CatalogInventories.First().Count = 10;
-                    _productService.Save(newProduct);
+                    //_productService.Save(newProduct);
+                //}
 
-                    //newProduct = _productService.GetByKey(newProduct.Key) as Product;
-                }
+                newProduct = product.ToProduct(newProduct);
+                _productService.Save(newProduct);
             }
             catch (Exception ex)
             {

--- a/src/Merchello.Web/Editors/ProductVariantApiController.cs
+++ b/src/Merchello.Web/Editors/ProductVariantApiController.cs
@@ -165,15 +165,16 @@ namespace Merchello.Web.Editors
 
                     newProductVariant = _productVariantService.CreateProductVariantWithKey(product, productVariant.Name, productVariant.Sku, productVariant.Price, productAttributes, true);
 
-                    if (!newProductVariant.Download)
+                    if (productVariant.TrackInventory)
                     {
                         newProductVariant.AddToCatalogInventory(_warehouseService.GetDefaultWarehouse().DefaultCatalog());
-                        newProductVariant.CatalogInventories.First().Count = 10;
-                        newProductVariant.CatalogInventories.First().LowCount = 3;
-                        //newProductVariant.Warehouses.First().Count = productVariant.WarehouseInventory.First().Count;
-                        //newProductVariant.Warehouses.First().LowCount = productVariant.WarehouseInventory.First().LowCount;
-                        _productVariantService.Save(newProductVariant);
+                        //newProductVariant.CatalogInventories.First().Count = 10;
+                        //newProductVariant.CatalogInventories.First().LowCount = 3;
                     }
+
+                    newProductVariant = productVariant.ToProductVariant(newProductVariant);
+
+                    _productVariantService.Save(newProductVariant);
                 }
                 else
                 {
@@ -202,6 +203,12 @@ namespace Merchello.Web.Editors
             try
             {
                 IProductVariant merchProductVariant = _productVariantService.GetByKey(productVariant.Key);
+
+                if (productVariant.TrackInventory && merchProductVariant.CatalogInventories.Count() == 0)
+                {
+                    merchProductVariant.AddToCatalogInventory(_warehouseService.GetDefaultWarehouse().DefaultCatalog());
+                }
+
                 merchProductVariant = productVariant.ToProductVariant(merchProductVariant);
 
                 _productVariantService.Save(merchProductVariant);

--- a/src/Merchello.Web/Models/ContentEditing/ProductMappingExtensions.cs
+++ b/src/Merchello.Web/Models/ContentEditing/ProductMappingExtensions.cs
@@ -196,12 +196,15 @@ namespace Merchello.Web.Models.ContentEditing
             {
                 ICatalogInventory destinationCatalogInventory;
 
-                var catInv = destination.CatalogInventories.Where(x => x.CatalogKey == catalogInventory.CatalogKey).First();
-                if (catInv != null)
+                if (destination.CatalogInventories.Count() > 0)
                 {
-                    destinationCatalogInventory = catInv;
+                    var catInv = destination.CatalogInventories.Where(x => x.CatalogKey == catalogInventory.CatalogKey).First();
+                    if (catInv != null)
+                    {
+                        destinationCatalogInventory = catInv;
 
-                    destinationCatalogInventory = catalogInventory.ToCatalogInventory(destinationCatalogInventory);
+                        destinationCatalogInventory = catalogInventory.ToCatalogInventory(destinationCatalogInventory);
+                    }
                 }
             }
 


### PR DESCRIPTION
New stuff:
- Default CatalogInventory for default variant / variants so the back-office always has a place to put and save inventory
- Changed variant on create to have a checkbox that defines "hasInventory" and the inventory count correctly
- Saving / creation fixes in the API as they relate to catalog inventory
- Disable inventory checkbox when downloadable product
