### PR TITLE
Housekeeping

### DIFF
--- a/src/Merchello.Core/Merchello.Core.csproj
+++ b/src/Merchello.Core/Merchello.Core.csproj
@@ -77,7 +77,6 @@
     <Compile Include="Builders\BuildChainBase.cs" />
     <Compile Include="Builders\InvoiceBuilderChain.cs" />
     <Compile Include="Builders\TaxationQuoteBuilderChain.cs" />
-    <Compile Include="Cache\CacheRefreshHelper.cs" />
     <Compile Include="Chains\AttemptChainTaskBase.cs" />
     <Compile Include="Chains\ChainTaskResolver.cs" />
     <Compile Include="Chains\InvoiceCreation\ApplyTaxesToInvoiceTax.cs" />


### PR DESCRIPTION
Removes the CacheRefreshHelper added as a temporary hack to the ProductVariant caching problem now that it was formally fix.
