### PR TITLE
Fix M-250: Update build script to work with VS12 and VS13

### DIFF
--- a/build/build.bat
+++ b/build/build.bat
@@ -1,6 +1,15 @@
 @ECHO OFF
 
-%windir%\Microsoft.NET\Framework\v4.0.30319\msbuild.exe "Merchello.build" /target:Build
+SET MSBuildLoc=
+SET MSBuild_VS12=C:\windows\Microsoft.NET\Framework\v4.0.30319\msbuild.exe
+SET MSBuild_VS13_32="C:\Program Files\MSBuild\12.0\bin\msbuild.exe"
+SET MSBuild_VS13_64="C:\Program Files (x86)\MSBuild\12.0\bin\msbuild.exe"
+
+if exist %MSBuild_VS12% SET MSBuildLoc=%MSBuild_VS12%
+if exist %MSBuild_VS13_32% SET MSBuildLoc=%MSBuild_VS13_32%
+if exist %MSBuild_VS13_64% SET MSBuildLoc=%MSBuild_VS13_64%
+
+%MSBuildLoc% "Merchello.build" /target:Build
 
 IF ERRORLEVEL 1 GOTO :showerror
 


### PR DESCRIPTION
The MSBuild path changed in VS2013, so those without VS2012 (or MSBuild) were getting some errors.  Updated Build.bat to conditionally determine the MSBuild location based on file existence.
