### PR TITLE
Product Editing in Content

### DIFF
--- a/src/Merchello.Core/Constants-ProductEditor.cs
+++ b/src/Merchello.Core/Constants-ProductEditor.cs
@@ -1,0 +1,14 @@
+﻿namespace Merchello.Core
+{
+    public partial class Constants
+    {
+        public static class ProductEditor
+        {
+            public static string ProductKeyPropertyAlias = "merchProductKey";
+            public static string TabAlias = "merchProductEditor";
+            public static string TabLabel = "Merchello Product";
+            public static int TabId = -666; // TODO: What ID should we use?
+            public static string PropertyAlias = "merchProductEditor";
+        }
+    }
+}

--- a/src/Merchello.Core/Merchello.Core.csproj
+++ b/src/Merchello.Core/Merchello.Core.csproj
@@ -232,6 +232,9 @@
     <Compile Include="Constants-ExtendedDataKeys.cs">
       <DependentUpon>Constants.cs</DependentUpon>
     </Compile>
+    <Compile Include="Constants-ProductEditor.cs">
+      <DependentUpon>Constants.cs</DependentUpon>
+    </Compile>
     <Compile Include="Gateways\GatewayContext.cs" />
     <Compile Include="Gateways\GatewayProviderBase.cs" />
     <Compile Include="Gateways\IGatewayContext.cs" />

--- a/src/Merchello.Web/AutoMapperMappings.cs
+++ b/src/Merchello.Web/AutoMapperMappings.cs
@@ -1,7 +1,10 @@
-﻿using Merchello.Core.Gateways;
+﻿using AutoMapper;
+using Merchello.Core.Gateways;
 using Merchello.Core.Models;
 using Merchello.Web.Models.ContentEditing;
 using Merchello.Web.Models.MapperResolvers;
+using Umbraco.Core.Models;
+using Umbraco.Web.Models.ContentEditing;
 
 namespace Merchello.Web
 {
@@ -61,6 +64,8 @@ namespace Merchello.Web
             BindPaymentMappings();
 
             BindWarehouseAndProductMappings();
+
+            ProductContentEditing.BindMappings();
         }
     }
 

--- a/src/Merchello.Web/Merchello.Web.csproj
+++ b/src/Merchello.Web/Merchello.Web.csproj
@@ -227,6 +227,7 @@
     <Compile Include="Models\MapperResolvers\ExtendedDataResolver.cs" />
     <Compile Include="Models\MapperResolvers\GatewayMethodDialogEditorViewResolver.cs" />
     <Compile Include="PackageActions\AddAppConfigKey.cs" />
+    <Compile Include="ProductContentEditing.cs" />
     <Compile Include="Workflow\PaymentProcessor.cs" />
     <Compile Include="Editors\SettingsApiController.cs" />
     <Compile Include="Editors\ShippingGatewayApiController.cs" />

--- a/src/Merchello.Web/ProductContentEditing.cs
+++ b/src/Merchello.Web/ProductContentEditing.cs
@@ -1,0 +1,63 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using AutoMapper;
+using Merchello.Core;
+using Umbraco.Core.Models;
+using Umbraco.Web.Models.ContentEditing;
+
+namespace Merchello.Web
+{
+    internal class ProductContentEditing
+    {
+        internal static void BindMappings()
+        {
+            Mapper.CreateMap<IContent, ContentItemDisplay>().AfterMap(HandleAfterMap);
+        }
+
+        internal static void HandleAfterMap(IContent content, ContentItemDisplay contentItem)
+        {
+            if (ShouldAddProductEditor(contentItem))
+                AddTab(contentItem);
+        }
+
+        private static void AddTab(ContentItemDisplay contentItem)
+        {
+            var tab = new Tab<ContentPropertyDisplay>();
+            tab.Alias = Constants.ProductEditor.TabAlias;
+            tab.Label = Constants.ProductEditor.TabLabel;
+            tab.Id = Constants.ProductEditor.TabId;
+            tab.IsActive = true;
+
+            AddProperties(ref tab);
+
+            //Is there a better way?
+            var tabs = new List<Tab<ContentPropertyDisplay>>();
+            tabs.Add(tab);
+            tabs.AddRange(contentItem.Tabs);
+            contentItem.Tabs = tabs;
+        }
+
+        private static bool ShouldAddProductEditor(ContentItemDisplay contentItem)
+        {
+            return contentItem.Properties.Any(p => p.Alias == Constants.ProductEditor.ProductKeyPropertyAlias);
+        }
+
+        private static void AddProperties(ref Tab<ContentPropertyDisplay> tab)
+        {
+            var listViewProperties = new List<ContentPropertyDisplay>();
+            listViewProperties.Add(new ContentPropertyDisplay
+            {
+                Alias = string.Concat(Umbraco.Core.Constants.PropertyEditors.InternalGenericPropertiesPrefix, Constants.ProductEditor.PropertyAlias), // Must prefix with _umb_ so Umbraco knows not to save this property
+                Label = "",
+                Value = null,
+                View = "boolean",
+                HideLabel = true,
+                Config = new Dictionary<string, object>()
+            });
+            tab.Properties = listViewProperties;
+        }
+    }
+}


### PR DESCRIPTION
WIP
- [x] Add virtual tab when `merchProductKey` property alias exists
- [ ] Attempt to create a wrapper PropertyEditor to wrap the actual forms
- [ ] Hook up PropertyEditor to save to Merchello when page is saved (via a webservice or Umbraco Content events?)
