### PR TITLE
Update TypeFieldElement.cs

### DIFF
--- a/src/Merchello.Core/Configuration/Outline/TypeFieldElement.cs
+++ b/src/Merchello.Core/Configuration/Outline/TypeFieldElement.cs
@@ -16,6 +16,7 @@
         /// <remarks>
         /// This corresponds to the alias field in the "merchDbTypeField" table
         /// </remarks>
+        [ConfigurationProperty("alias", IsKey = true)]
         public string Alias
         {
             get { return (string)this["alias"]; }


### PR DESCRIPTION
If you add a custom type field definition in merchello.config you get an exception because the configuration property is missing.
