### PR TITLE
Change cartItem data related to shipment

### DIFF
--- a/src/Merchello.Core/Models/LineItemExtensions.cs
+++ b/src/Merchello.Core/Models/LineItemExtensions.cs
@@ -253,7 +253,7 @@
                 {
                     EnumTypeFieldConverter.LineItemType.Shipping.TypeKey,
                     shipmentRateQuote.ShipmentLineItemName(),
-                    shipmentRateQuote.ShipMethod.ServiceCode, // TODO this may not be unique (SKU) once multiple shipments are exposed
+                    shipmentRateQuote.ShipMethod.Key.ToString(),//OLD shipmentRateQuote.ShipMethod.ServiceCode, // TODO this may not be unique (SKU) once multiple shipments are exposed
                     1,
                     shipmentRateQuote.Rate,
                     extendedData


### PR DESCRIPTION
I would like to develop a one page checkout. To do it, I should know which type of payment method the customer set before. So I save the shipment method key in the cart item. Is it correct?
