### PR TITLE
M-548 Fixing currency symbol 

### DIFF
--- a/src/Merchello.Web.UI/App_Plugins/Merchello/Backoffice/Merchello/CustomerList.html
+++ b/src/Merchello.Web.UI/App_Plugins/Merchello/Backoffice/Merchello/CustomerList.html
@@ -94,7 +94,7 @@
                             <td><a href="#/merchello/merchello/CustomerView/{{customer.key}}">{{customer.loginName}}</a></td>
                             <td><a href="#/merchello/merchello/CustomerView/{{customer.key}}">{{customer.firstName}} {{customer.lastName}}</a></td>
                             <td>{{customer.primaryLocation()}}</td>
-                            <td><localize key="merchelloGeneral_moneySymbol" />{{customer.invoiceTotal}}</td>
+                            <td>{{customer.invoiceTotal | currency : currencySymbol}}</td>
                         </tr>
                     </tbody>
                 </table>

--- a/src/Merchello.Web.UI/App_Plugins/Merchello/Backoffice/Merchello/CustomerView.html
+++ b/src/Merchello.Web.UI/App_Plugins/Merchello/Backoffice/Merchello/CustomerView.html
@@ -42,12 +42,12 @@
                                     <td>{{invoice.invoiceDate}}</td>
                                     <td><span class="label" data-ng-class="{ 'label-success': invoice.getPaymentStatus()=='Paid', 'label-info': invoice.getPaymentStatus()=='Unpaid' }"><i data-ng-class="{ 'icon-check': invoice.getPaymentStatus()=='Paid', 'icon-loading': invoice.getPaymentStatus()=='Unpaid' }"></i> {{invoice.getPaymentStatus()}}</span></td>
                                     <td><span class="label" data-ng-class="{ 'label-success': invoice.getFulfillmentStatus()=='Fulfilled', 'label-warning': invoice.getFulfillmentStatus()=='Not Fulfilled', 'label-info': invoice.getFulfillmentStatus()=='Partial' }"><i data-ng-class="{ 'icon-check': invoice.getFulfillmentStatus()=='Fulfilled', 'icon-alert': invoice.getFulfillmentStatus()=='Not Fulfilled', 'icon-loading': invoice.getFulfillmentStatus()=='Partial' }"></i> {{invoice.getFulfillmentStatus()}}</span></td>
-                                    <td><localize key="merchelloGeneral_moneySymbol" />{{invoice.total}}</td>
+                                    <td>{{invoice.total | currency : currencySymbol}}</td>
                                 </tr>
                                 <tr>
                                     <td colspan="4"></td>
                                     <td>Total Spent:</td>
-                                    <td><localize key="merchelloGeneral_moneySymbol" />{{invoiceTotal}}</td>
+                                    <td>{{invoiceTotal | currency : currencySymbol}}</td>
                                 </tr>
                             </tbody>
                         </table>

--- a/src/Merchello.Web.UI/App_Plugins/Merchello/Backoffice/Merchello/OrderPaymentInfo.html
+++ b/src/Merchello.Web.UI/App_Plugins/Merchello/Backoffice/Merchello/OrderPaymentInfo.html
@@ -43,7 +43,7 @@
                                     <tr data-ng-repeat="payment in invoice.appliedPayments">
                                         <td>{{formatDate(payment.createDate)}}</td>
                                         <td>{{payment.description}}</td>
-                                        <td>{{payment.amount}}</td>
+                                        <td>{{payment.amount | currency : currencySymbol}}</td>
                                         <!--td><a href="#">Void</a> | <a href="#">Refund</a></td-->
                                     </tr>
                                 </tbody>

--- a/src/Merchello.Web.UI/App_Plugins/Merchello/Modules/Customer/customer.list.controller.js
+++ b/src/Merchello.Web.UI/App_Plugins/Merchello/Modules/Customer/customer.list.controller.js
@@ -8,7 +8,7 @@
      * @description
      * The controller for the customers list page
      */
-    controllers.CustomerListController = function ($scope, dialogService, assetsService, merchelloCustomerService, merchelloInvoiceService, notificationsService) {
+    controllers.CustomerListController = function ($scope, dialogService, assetsService, merchelloCustomerService, merchelloInvoiceService, notificationsService, merchelloSettingsService) {
 
         assetsService.loadCss("/App_Plugins/Merchello/Common/Css/merchello.css");
 
@@ -52,6 +52,25 @@
 
         /**
          * @ngdoc method
+         * @name loadSettings
+         * @function
+         * 
+         * @description
+         * Load the settings from the settings service to get the currency symbol
+         */
+        $scope.loadSettings = function () {
+
+            var currencySymbolPromise = merchelloSettingsService.getCurrencySymbol();
+            currencySymbolPromise.then(function (currencySymbol) {
+                $scope.currencySymbol = currencySymbol;
+
+            }, function (reason) {
+                notificationsService.error("Settings Load Failed", reason.message);
+            });
+        };
+
+        /**
+         * @ngdoc method
          * @name init
          * @function
          * 
@@ -61,6 +80,7 @@
         $scope.init = function () {
             $scope.setVariables();
             $scope.loadCustomers();
+            $scope.loadSettings();
         };
 
         /**
@@ -255,6 +275,6 @@
     };
 
 
-    angular.module("umbraco").controller("Merchello.Dashboards.Customer.ListController", ['$scope', 'dialogService', 'assetsService', 'merchelloCustomerService', 'merchelloInvoiceService', 'notificationsService', merchello.Controllers.CustomerListController]);
+    angular.module("umbraco").controller("Merchello.Dashboards.Customer.ListController", ['$scope', 'dialogService', 'assetsService', 'merchelloCustomerService', 'merchelloInvoiceService', 'notificationsService', 'merchelloSettingsService', merchello.Controllers.CustomerListController]);
 
 }(window.merchello.Controllers = window.merchello.Controllers || {}));

--- a/src/Merchello.Web.UI/App_Plugins/Merchello/Modules/Customer/customer.view.controller.js
+++ b/src/Merchello.Web.UI/App_Plugins/Merchello/Modules/Customer/customer.view.controller.js
@@ -64,6 +64,26 @@
             $scope.setVariables();
             $scope.loadCountries();
             $scope.loadCustomer();
+            $scope.loadSettings();
+        };
+
+        /**
+         * @ngdoc method
+         * @name loadSettings
+         * @function
+         * 
+         * @description
+         * Load the settings from the settings service to get the currency symbol
+         */
+        $scope.loadSettings = function () {
+
+            var currencySymbolPromise = merchelloSettingsService.getCurrencySymbol();
+            currencySymbolPromise.then(function (currencySymbol) {
+                $scope.currencySymbol = currencySymbol;
+
+            }, function (reason) {
+                notificationsService.error("Settings Load Failed", reason.message);
+            });
         };
 
         /**

--- a/src/Merchello.Web.UI/App_Plugins/Merchello/Modules/Order/Dialogs/capture.payment.controller.js
+++ b/src/Merchello.Web.UI/App_Plugins/Merchello/Modules/Order/Dialogs/capture.payment.controller.js
@@ -17,10 +17,10 @@
         $scope.payments = {};
 
         $scope.paymentRequest = new merchello.Models.PaymentRequest();
-        $scope.paymentRequest.invoiceKey = $scope.dialogData.key;
-        $scope.paymentRequest.amount = round($scope.dialogData.total, 2);
+        $scope.paymentRequest.invoiceKey = $scope.dialogData.invoice.key;
+        $scope.paymentRequest.amount = round($scope.dialogData.invoice.total, 2);
 
-	    var payments = _.map($scope.dialogData.appliedPayments, function(appliedPayment) {
+	    var payments = _.map($scope.dialogData.invoice.appliedPayments, function(appliedPayment) {
 		    return appliedPayment.payment;
 	    });
 

--- a/src/Merchello.Web.UI/App_Plugins/Merchello/Modules/Order/Dialogs/capture.payment.html
+++ b/src/Merchello.Web.UI/App_Plugins/Merchello/Modules/Order/Dialogs/capture.payment.html
@@ -4,35 +4,36 @@
     </div>
     <div class="umb-panel-body with-header with-footer">
         
-            <div class="control-group row-fluid">
-                <p>
-                    <localize key="merchelloOrder_processedBy" /> <strong>{{payments.paymentMethodName}}</strong><br />
-                    <!--<i class="icon-credit-card"></i> Credit Card: <span>XXXX-XXXX-XXXX-1234</span>-->
-                </p>
-                <div class="input-prepend col-xs-12 span12">
-                    <span class="add-on"><localize key="merchelloGeneral_moneySymbol" /></span>
-                    <input class="col-xs-4 span4" type="text" data-ng-model="paymentRequest.amount">
-                </div>
+        <div class="control-group row-fluid">
+            <p>
+                <localize key="merchelloOrder_processedBy" /> <strong>{{payments.paymentMethodName}}</strong><br />
+                <!--<i class="icon-credit-card"></i> Credit Card: <span>XXXX-XXXX-XXXX-1234</span>-->
+            </p>
+            <div class="input-prepend col-xs-12 span12">
+                <span class="add-on">{{dialogData.currencySymbol}}</span>
+                <input class="col-xs-4 span4" type="text" data-ng-model="paymentRequest.amount">
             </div>
+        </div>
 
     </div>
 
-	<div class="umb-panel-footer" >
-		<div class="umb-el-wrap umb-panel-buttons">
-	        <div class="btn-toolbar umb-btn-toolbar pull-right">
+    <div class="umb-panel-footer" >
+        <div class="umb-el-wrap umb-panel-buttons">
+            <div class="btn-toolbar umb-btn-toolbar pull-right">
 
-	        	<a href data-ng-click="close()" class="btn btn-link">
-	        		<localize key="general_cancel">Cancel</localize>
-				</a>
+                <a href data-ng-click="close()" class="btn btn-link">
+                    <localize key="general_cancel">Cancel</localize>
+                </a>
 
-				<button
-					class="btn btn-primary"
-					data-ng-click="submit(paymentRequest)">
+                <button
+                    class="btn btn-primary"
+                    data-ng-click="submit(paymentRequest)">
                     <localize key="merchelloOrder_processPayment" />
-				</button>
+                </button>
 
-	        </div>
-		</div>
-	</div>
+            </div>
+        </div>
+    </div>
 </div>
+
 

--- a/src/Merchello.Web.UI/App_Plugins/Merchello/Modules/Order/order.payment.info.controller.js
+++ b/src/Merchello.Web.UI/App_Plugins/Merchello/Modules/Order/order.payment.info.controller.js
@@ -55,11 +55,21 @@
          * Open the capture shipment dialog.
          */
         $scope.capturePayment = function () {
+
+            var dialogData = {
+                invoice: $scope.invoice,
+                currencySymbol: $scope.currencySymbol
+            };
+
             dialogService.open({
+
+                /// TODO: DFB - m-548 pass global settings into both dialogs
+                /// in order to get rid of dependency on merchelloGeneral_moneySymbol 
+
                 template: '/App_Plugins/Merchello/Modules/Order/Dialogs/capture.payment.html',
                 show: true,
                 callback: $scope.capturePaymentDialogConfirm,
-                dialogData: $scope.invoice
+                dialogData: dialogData
             });
         };
 
@@ -160,7 +170,7 @@
                     invoice.payments = _.uniq(_.map(invoice.appliedPayments, function (appliedPayment) {
                         return appliedPayment.payment;
                     }));
-                }
+                }http://localhost:58400/Dialogs
                 _.each(invoice.appliedPayments, function (appliedPayment) {
                     if (appliedPayment.appliedPaymentTfKey) {
                         var matchedTypeField = _.find($scope.typeFields, function (type) {

--- a/src/Merchello.Web.UI/App_Plugins/Merchello/Modules/Order/order.view.controller.js
+++ b/src/Merchello.Web.UI/App_Plugins/Merchello/Modules/Order/order.view.controller.js
@@ -228,11 +228,21 @@
          * @description - Open the capture shipment dialog.
          */
         $scope.capturePayment = function () {
+
+            /// TODO: DFB - m-548 pass global settings into both dialogs
+            /// in order to get rid of dependency on merchelloGeneral_moneySymbol 
+            /// merchelloSettingsService is already passed in
+
+            var dialogData = {
+                invoice: $scope.invoice,
+                currencySymbol: $scope.currencySymbol
+            };
+
             dialogService.open({
                 template: '/App_Plugins/Merchello/Modules/Order/Dialogs/capture.payment.html',
                 show: true,
                 callback: $scope.capturePaymentDialogConfirm,
-                dialogData: $scope.invoice
+                dialogData: dialogData
             });
         };
 

--- a/src/Merchello.Web.UI/App_Plugins/Merchello/Modules/Settings/Shipping/Dialogs/shippingmethod.html
+++ b/src/Merchello.Web.UI/App_Plugins/Merchello/Modules/Settings/Shipping/Dialogs/shippingmethod.html
@@ -30,7 +30,7 @@
                     </td>
                     <td>
                         <div class="input-prepend">
-                            <span class="add-on"><localize key="merchelloGeneral_moneySymbol" /></span>
+                            <span class="add-on">{{dialogData.currencySymbol}}</span>
                             <input type="number" data-ng-model="tier.rate" class="span2 col-xs-2" />
                         </div>
                     </td>
@@ -47,7 +47,7 @@
                     </td>
                     <td>
                         <div class="input-prepend">
-                            <span class="add-on"><localize key="merchelloGeneral_moneySymbol" /></span>
+                            <span class="add-on">{{dialogData.currencySymbol}}</span>
                             <input type="number" data-ng-model="newTier.rate" class="span1 col-xs-1" />
                         </div>
                     </td>

--- a/src/Merchello.Web.UI/App_Plugins/Merchello/Modules/Settings/Shipping/Dialogs/shippingregions.html
+++ b/src/Merchello.Web.UI/App_Plugins/Merchello/Modules/Settings/Shipping/Dialogs/shippingregions.html
@@ -29,13 +29,13 @@
                         </td>
                         <td class="col-xs-4 span4 row-fluid">
                             <div data-ng-class="{'input-prepend': province.rateAdjustmentType == 1, 'input-append': province.rateAdjustmentType == 2 }">
-                                <span class="add-on" data-ng-show="province.rateAdjustmentType == 1"><localize key="merchelloGeneral_moneySymbol" /></span>
+                                <span class="add-on" data-ng-show="province.rateAdjustmentType == 1">{{dialogData.currencySymbol}}</span>
                                 <input type="number" data-ng-model="province.rateAdjustment" class="span8 col-xs-8" />
                                 <span class="add-on" data-ng-show="province.rateAdjustmentType == 2"><localize key="merchelloGeneral_percentSymbol" /></span>
                             </div>
                         </td>
                         <td class="col-xs-2 span2 row-fluid">
-                            <label class="col-xs-6 span6"><input type="radio" data-ng-model="province.rateAdjustmentType" value="1" /> <localize key="merchelloGeneral_moneySymbol" /></label>
+                            <label class="col-xs-6 span6"><input type="radio" data-ng-model="province.rateAdjustmentType" value="1" /> {{dialogData.currencySymbol}}</label>
                             <label class="col-xs-6 span6"><input type="radio" data-ng-model="province.rateAdjustmentType" value="2" /> <localize key="merchelloGeneral_percentSymbol" /></label>
                         </td>
                     </tr>

--- a/src/Merchello.Web.UI/App_Plugins/Merchello/Modules/Settings/Shipping/shipping.controller.js
+++ b/src/Merchello.Web.UI/App_Plugins/Merchello/Modules/Settings/Shipping/shipping.controller.js
@@ -26,6 +26,25 @@
 	        $scope.setVariables();
 	        $scope.loadWarehouses();
 	        $scope.loadAllAvailableCountries();
+	        $scope.loadSettings();
+	    };
+
+	    /**
+         * @ngdoc method
+         * @name loadSettings
+         * @function
+         * 
+         * @description
+         * Load the Merchello settings.
+         */
+	    $scope.loadSettings = function () {
+	        var currencySymbolPromise = merchelloSettingsService.getCurrencySymbol();
+	        currencySymbolPromise.then(function (currencySymbol) {
+	            $scope.currencySymbol = currencySymbol;
+
+	        }, function (reason) {
+	            alert('Failed: ' + reason.message);
+	        });
 	    };
 
 	    /**
@@ -516,7 +535,8 @@
 		        method: dialogMethod,
 		        country: country,
 		        provider: gatewayProvider,
-		        gatewayResources: availableResources
+		        gatewayResources: availableResources,
+		        currencySymbol: $scope.currencySymbol
 		    };
 		    dialogService.open({
 		        template: templatePage,
@@ -749,6 +769,9 @@
         */
 		$scope.editRegionalShippingRatesDialogOpen = function (country, provider, method) {
 
+		    /// TODO: DFB - m-548 pass global settings into both dialogs
+		    /// in order to get rid of dependency on merchelloGeneral_moneySymbol 
+
 		    var dialogMethod = method;
 		    var availableResources = provider.resources;
 		    var templatePage = '/App_Plugins/Merchello/Modules/Settings/Shipping/Dialogs/shippingregions.html';
@@ -764,7 +787,8 @@
 		        method: dialogMethod,
 		        country: country,
 		        provider: provider,
-		        gatewayResources: availableResources
+		        gatewayResources: availableResources,
+		        currencySymbol: $scope.currencySymbol
 		    };
 
 		    dialogService.open({


### PR DESCRIPTION
The currency symbol on several dialogs still uses _moneySymbol instead of this syntax. I need help from Rusty to figure out how to debug the right-side fly-in windows like capture.payment. When I tried to use the same fix as these fixes for that dialog, the entire dialog quit working