### PR TITLE
Extended Merchello's ProductService with method "GetBySku"

### DIFF
--- a/src/Merchello.Core/Persistence/Repositories/Interfaces/IProductRepository.cs
+++ b/src/Merchello.Core/Persistence/Repositories/Interfaces/IProductRepository.cs
@@ -14,5 +14,12 @@
         /// <param name="sku">The sku to be tested</param>
         /// <returns>A value indicating whether or not a sku is already exists in the database</returns>
         bool SkuExists(string sku);
+        
+        /// <summary>
+        /// Get IProduct by Sku
+        /// </summary>
+        /// <param name="sku"></param>
+        /// <returns></returns>
+        IProduct Get(string sku);        
     }
 }

--- a/src/Merchello.Core/Services/Interfaces/IProductService.cs
+++ b/src/Merchello.Core/Services/Interfaces/IProductService.cs
@@ -80,6 +80,13 @@
         IEnumerable<IProduct> GetByKeys(IEnumerable<Guid> keys);
 
         /// <summary>
+        /// Gets a <see cref="IProduct"/> object by Sku
+        /// </summary>
+        /// <param name="sku">Sku of Product object to retrieve</param>
+        /// <returns>A single <see cref="IProduct"/></returns>
+        IProduct GetBySku(string sku);
+
+        /// <summary>
         /// Gets a collection of all <see cref="IProduct"/>.
         /// </summary>
         /// <returns>

--- a/src/Merchello.Core/Services/ProductService.cs
+++ b/src/Merchello.Core/Services/ProductService.cs
@@ -346,6 +346,19 @@
         }
 
         /// <summary>
+        /// Gets a Product by its unique SKU
+        /// </summary>
+        /// <param name="sku">Unique SKU  for the Product</param>
+        /// <returns><see cref="IProductVariant"/></returns>
+        public IProduct GetBySku(string sku)
+        {
+            using (var repository = _repositoryFactory.CreateProductRepository(_uowProvider.GetUnitOfWork()))
+            {
+                return repository.Get(sku);
+            }
+        }
+
+        /// <summary>
         /// Gets a page of <see cref="IProduct"/>
         /// </summary>
         /// <param name="page">


### PR DESCRIPTION
Hi,

I've created my first code using the ProductService but was surprised that there is a method "SkuExists(...)" but that there wasn't a method GetBySku(...). Similar to GetByKey but then with the product's Sku.
So, I've made additions to the Repository and ProductService (both Interface and inheriting class).

Keep up the excellent work!
Kind regards, Steven