### PR TITLE
Change markup for header/title

### DIFF
--- a/src/Merchello.Web.UI.Client/src/views/customers/customeraddresses.html
+++ b/src/Merchello.Web.UI.Client/src/views/customers/customeraddresses.html
@@ -1,12 +1,12 @@
 <div data-ng-controller="Merchello.Backoffice.CustomerAddressesController" data-ng-show="loaded">
     <umb-panel>
         <umb-header>
-            <div class="span4">
+            <div class="span7">
                 <div class="umb-headline-editor-wrapper">
-                    <h1 class="umb-headline"><localize key="merchelloOrder_sales" /> / <localize key="merchelloOrderView_invoiceNumber" />{{invoice.invoiceNumber}}</h1>
+                    <h1><localize key="merchelloOrder_sales" /> / <localize key="merchelloOrderView_invoiceNumber" />{{invoice.invoiceNumber}}</h1>
                 </div>
             </div>
-            <div class="span8">
+            <div class="span5">
                 <div class="btn-toolbar pull-right umb-btn-toolbar">
                     <!-- New Order Button -->
                     <div class="btn-group">

--- a/src/Merchello.Web.UI.Client/src/views/customers/customerlist.html
+++ b/src/Merchello.Web.UI.Client/src/views/customers/customerlist.html
@@ -1,12 +1,12 @@
 <div ng-controller="Merchello.Backoffice.CustomerListController" ng-show="loaded">
     <umb-panel>
         <umb-header>
-            <div class="span4">
+            <div class="span7">
                 <div class="umb-headline-editor-wrapper">
-                    <h1 class="umb-headline">Customers</h1>
+                    <h1>Customers</h1>
                 </div>
             </div>
-            <div class="span8">
+            <div class="span5">
                 <div class="btn-toolbar pull-right umb-btn-toolbar">
                     <!-- New Order Button -->
                     <div class="btn-group">

--- a/src/Merchello.Web.UI.Client/src/views/customers/customeroverview.html
+++ b/src/Merchello.Web.UI.Client/src/views/customers/customeroverview.html
@@ -1,12 +1,12 @@
 <form novalidate name="customerForm" data-ng-controller="Merchello.Backoffice.CustomerOverviewController" data-ng-show="loaded" data-ng-submit="save()">
     <umb-panel val-show-validation>
         <umb-header>
-            <div class="span4">
+            <div class="span7">
                 <div class="umb-headline-editor-wrapper">
-                    <h1 class="umb-headline">{{customer.firstName}} {{customer.lastName}}</h1>
+                    <h1>{{customer.firstName}} {{customer.lastName}}</h1>
                 </div>
             </div>
-            <div class="span8">
+            <div class="span5">
                 <div class="btn-toolbar pull-right umb-btn-toolbar">
                     <div class="btn-group">
                         <!-- ACTION: Delete Customer -->

--- a/src/Merchello.Web.UI.Client/src/views/dashboards/dashboard.html
+++ b/src/Merchello.Web.UI.Client/src/views/dashboards/dashboard.html
@@ -1,5 +1,5 @@
 
-<h1 class="umb-headline">Merchello, the eCommerce package</h1>
+<h1>Merchello, the eCommerce package</h1>
 <br />
 Learn about Merchello in the <a href="http://merchello.com/documentation/">Documentation</a><br />
 Read about the latest news on our <a href="http://merchello.com/blog">Blog</a><br />

--- a/src/Merchello.Web.UI.Client/src/views/gatewayproviders/gatewayproviderlist.html
+++ b/src/Merchello.Web.UI.Client/src/views/gatewayproviders/gatewayproviderlist.html
@@ -1,12 +1,12 @@
 <div data-ng-controller="Merchello.Backoffice.GatewayProvidersListController" data-ng-show="loaded">
     <umb-panel>
         <umb-header>
-            <div class="span4">
+            <div class="span7">
                 <div class="umb-headline-editor-wrapper">
-                    <h1 class="umb-headline"><localize key="merchelloGatewayProvider_gatewayProvider" /></h1>
+                    <h1><localize key="merchelloGatewayProvider_gatewayProvider" /></h1>
                 </div>
             </div>
-            <div class="span8">
+            <div class="span5">
                 <div class="btn-toolbar pull-right umb-btn-toolbar">
                     <div class="btn-group">
                     </div>

--- a/src/Merchello.Web.UI.Client/src/views/gatewayproviders/notification.messageeditor.html
+++ b/src/Merchello.Web.UI.Client/src/views/gatewayproviders/notification.messageeditor.html
@@ -3,12 +3,12 @@
     <!-- This is the umb-panel directive. We removed it because the ui-codemirror directive doesn't work nested under another directive.-->
     <div>
         <umb-header>
-            <div class="span8">
+            <div class="span7">
                 <div class="umb-headline-editor-wrapper">
-                    <h1 class="umb-headline">{{notificationMessage.name}} <localize key="merchelloNotifications_notifications" /></h1>
+                    <h1>{{notificationMessage.name}} <localize key="merchelloNotifications_notifications" /></h1>
                 </div>
             </div>
-            <div class="span4">
+            <div class="span5">
                 <div class="btn-toolbar pull-right umb-btn-toolbar">
                     <div class="btn-group">
                         <a href="#/merchello/merchello/Notifications/manage" class="btn"><localize key="general_cancel" /></a>

--- a/src/Merchello.Web.UI.Client/src/views/gatewayproviders/notificationproviders.html
+++ b/src/Merchello.Web.UI.Client/src/views/gatewayproviders/notificationproviders.html
@@ -2,18 +2,14 @@
 
     <umb-panel>
         <umb-header>
-
-            <div class="span4">
+            <div class="span7">
                 <div class="umb-headline-editor-wrapper">
-                    <h1 class="umb-headline"><localize key="merchelloNotifications_notifications" /></h1>
+                    <h1><localize key="merchelloNotifications_notifications" /></h1>
                 </div>
             </div>
-
-            <div class="span8">
+            <div class="span5">
                 <div class="btn-toolbar pull-right umb-btn-toolbar">
-
                     <div class="btn-group">
-
                     </div>
                 </div>
             </div>

--- a/src/Merchello.Web.UI.Client/src/views/gatewayproviders/paymentproviders.html
+++ b/src/Merchello.Web.UI.Client/src/views/gatewayproviders/paymentproviders.html
@@ -2,22 +2,15 @@
 <div data-ng-controller="Merchello.Backoffice.PaymentProvidersController"  data-ng-show="loaded">
 
     <umb-panel>
-
         <umb-header>
-
-            <div class="span4">
+            <div class="span7">
                 <div class="umb-headline-editor-wrapper">
-                    <h1 class="umb-headline"><localize key="merchelloPayment_payment" /></h1>
+                    <h1><localize key="merchelloPayment_payment" /></h1>
                 </div>
             </div>
-
-
-            <div class="span8">
+            <div class="span5">
                 <div class="btn-toolbar pull-right umb-btn-toolbar">
-
                     <div class="btn-group">
-
-
                     </div>
                 </div>
             </div>

--- a/src/Merchello.Web.UI.Client/src/views/gatewayproviders/shippingproviders.html
+++ b/src/Merchello.Web.UI.Client/src/views/gatewayproviders/shippingproviders.html
@@ -1,12 +1,12 @@
 <div data-ng-controller="Merchello.Backoffice.ShippingProvidersController" data-ng-show="loaded">
     <umb-panel>
         <umb-header>
-            <div class="span4">
+            <div class="span7">
                 <div class="umb-headline-editor-wrapper">
-                    <h1 class="umb-headline">{{selectedCatalog.name}}: Shipping Providers & Methods</h1>
+                    <h1>{{selectedCatalog.name}}: Shipping Providers & Methods</h1>
                 </div>
             </div>
-            <div class="span8">
+            <div class="span5">
                 <div class="btn-toolbar pull-right umb-btn-toolbar">
                     <div class="btn-group">
                         <a class="btn-primary btn" data-ng-click="changeSelectedCatalogOpen()" data-ng-show="primaryWarehouse.warehouseCatalogs.length > 1">Select Catalog</a>

--- a/src/Merchello.Web.UI.Client/src/views/gatewayproviders/taxationproviders.html
+++ b/src/Merchello.Web.UI.Client/src/views/gatewayproviders/taxationproviders.html
@@ -1,17 +1,12 @@
 <div data-ng-controller="Merchello.Backoffice.TaxationProvidersController" data-ng-show="loaded">
-
     <umb-panel>
-
         <umb-header>
-
-            <div class="span4">
+            <div class="span7">
                 <div class="umb-headline-editor-wrapper">
-                    <h1 class="umb-headline"><localize key="merchelloTaxation_taxation" /> </h1>
+                    <h1><localize key="merchelloTaxation_taxation" /></h1>
                 </div>
             </div>
-
-
-            <div class="span8">
+            <div class="span5">
                 <div class="btn-toolbar pull-right umb-btn-toolbar">
                     <div class="btn-group">
                         <a class="btn btn-primary" data-ng-click="save()"><localize key="buttons_save" /></a>

--- a/src/Merchello.Web.UI.Client/src/views/products/productedit.html
+++ b/src/Merchello.Web.UI.Client/src/views/products/productedit.html
@@ -1,16 +1,12 @@
 <form novalidate name="productVariantForm" data-ng-controller="Merchello.Backoffice.ProductEditController"
       data-ng-show="loaded" data-ng-submit="save()">
     <umb-panel val-show-validation>
-
         <umb-header>
-
-            <div class="span4">
-                <umb-content-name ng-model="productVariant.name"
-                                  localize="placeholder" placeholder="@merchelloPlaceholders_enterProduct">
+            <div class="span7">
+                <umb-content-name ng-model="productVariant.name" localize="placeholder" placeholder="@merchelloPlaceholders_enterProduct">
                 </umb-content-name>
             </div>
-
-            <div class="col-xs-8 span8">
+            <div class="span5">
                 <div class="btn-toolbar pull-right umb-btn-toolbar">
                     <div class="btn-group">
                         <a data-ng-click="deleteProductDialog()" data-ng-show="context !== 'varianteditor' && context !== 'createproduct'" class="btn"><localize key="merchelloVariant_deleteProduct" /></a>

--- a/src/Merchello.Web.UI.Client/src/views/products/productlist.html
+++ b/src/Merchello.Web.UI.Client/src/views/products/productlist.html
@@ -1,14 +1,12 @@
 <div ng-controller="Merchello.Backoffice.ProductListController" ng-show="loaded">
-
     <umb-panel>
         <umb-header>
-            <div class="span4">
+            <div class="span7">
                 <div class="umb-headline-editor-wrapper">
-                    <h1 class="umb-headline"><localize key="merchelloHeadline_catalog" /></h1>
+                    <h1><localize key="merchelloHeadline_catalog" /></h1>
                 </div>
             </div>
-
-            <div class="span8">
+            <div class="span5">
                 <div class="btn-toolbar pull-right umb-btn-toolbar">
                     <div class="btn-group">
                         <a href="#/merchello/merchello/productedit/create" class="btn btn-primary"><localize key="merchelloVariant_newProduct" /></a>

--- a/src/Merchello.Web.UI.Client/src/views/reports/reportslist.html
+++ b/src/Merchello.Web.UI.Client/src/views/reports/reportslist.html
@@ -1,24 +1,14 @@
-
-<div
-        ng-controller="Merchello.Backoffice.ReportsListController" ng-show="loaded">
-
+<div ng-controller="Merchello.Backoffice.ReportsListController" ng-show="loaded">
     <umb-panel>
-
         <umb-header>
-
-            <div class="span4">
+            <div class="span7">
                 <div class="umb-headline-editor-wrapper">
-                    <h1 class="umb-headline">Reports</h1>
+                    <h1>Reports</h1>
                 </div>
             </div>
-
-
-            <div class="span8">
+            <div class="span5">
                 <div class="btn-toolbar pull-right umb-btn-toolbar">
-
                     <div class="btn-group">
-
-
                     </div>
                 </div>
             </div>

--- a/src/Merchello.Web.UI.Client/src/views/sales/invoicepayments.html
+++ b/src/Merchello.Web.UI.Client/src/views/sales/invoicepayments.html
@@ -1,12 +1,12 @@
 <div data-ng-controller="Merchello.Backoffice.InvoicePaymentsController" data-ng-show="loaded">
     <umb-panel>
         <umb-header>
-            <div class="span4">
+            <div class="span7">
                 <div class="umb-headline-editor-wrapper">
-                    <h1 class="umb-headline"><localize key="merchelloOrder_sales" /> / <localize key="merchelloOrderView_invoiceNumber" />{{invoice.invoiceNumber}}</h1>
+                    <h1><localize key="merchelloOrder_sales" /> / <localize key="merchelloOrderView_invoiceNumber" />{{invoice.invoiceNumber}}</h1>
                 </div>
             </div>
-            <div class="span8">
+            <div class="span5">
                 <div class="btn-toolbar pull-right umb-btn-toolbar">
                     <!-- New Order Button -->
                     <div class="btn-group">

--- a/src/Merchello.Web.UI.Client/src/views/sales/ordershipments.html
+++ b/src/Merchello.Web.UI.Client/src/views/sales/ordershipments.html
@@ -1,12 +1,12 @@
 <div data-ng-controller="Merchello.Backoffice.OrderShipmentsController" data-ng-show="loaded">
     <umb-panel>
         <umb-header>
-            <div class="span4">
+            <div class="span7">
                 <div class="umb-headline-editor-wrapper">
-                    <h1 class="umb-headline"><localize key="merchelloOrder_sales" /> / <localize key="merchelloOrderView_invoiceNumber" />{{invoice.invoiceNumber}}</h1>
+                    <h1><localize key="merchelloOrder_sales" /> / <localize key="merchelloOrderView_invoiceNumber" />{{invoice.invoiceNumber}}</h1>
                 </div>
             </div>
-            <div class="span8">
+            <div class="span5">
                 <div class="btn-toolbar pull-right umb-btn-toolbar">
                     <!-- New Order Button -->
                     <div class="btn-group">

--- a/src/Merchello.Web.UI.Client/src/views/sales/saleoverview.html
+++ b/src/Merchello.Web.UI.Client/src/views/sales/saleoverview.html
@@ -1,14 +1,12 @@
 <form novalidate name="orderForm" data-ng-controller="Merchello.Backoffice.SalesOverviewController" data-ng-show="loaded">
     <umb-panel val-show-validation>
         <umb-header>
-            <div class="span4">
+            <div class="span7">
                 <div class="umb-headline-editor-wrapper">
-                    <h1 class="umb-headline"><localize key="merchelloOrder_sales" /> / <localize key="merchelloOrderView_invoiceNumber" />{{invoice.invoiceNumber}}<br />
-
-                    </h1>
+                    <h1><localize key="merchelloOrder_sales" /> / <localize key="merchelloOrderView_invoiceNumber" />{{invoice.invoiceNumber}}</h1>
                 </div>
             </div>
-            <div class="span8">
+            <div class="span5">
                 <div class="btn-toolbar pull-right umb-btn-toolbar">
                     <!-- ACTION: Refund -->
                     <span class="btn">{{invoice.invoiceDateString() | date : settings.dateFormat }}</span>

--- a/src/Merchello.Web.UI.Client/src/views/sales/saleslist.html
+++ b/src/Merchello.Web.UI.Client/src/views/sales/saleslist.html
@@ -1,12 +1,12 @@
 ﻿<div ng-controller="Merchello.Backoffice.SalesListController" ng-show="loaded">
     <umb-panel>
         <umb-header>
-            <div class="span4">
+            <div class="span7">
                 <div class="umb-headline-editor-wrapper">
-                    <h1 class="umb-headline"><localize key="merchelloOrder_sales" /></h1>
+                    <h1><localize key="merchelloOrder_sales" /></h1>
                 </div>
             </div>
-            <div class="span8">
+            <div class="span5">
                 <div class="btn-toolbar pull-right umb-btn-toolbar">
                     <!-- New Order Button
                         <div class="btn-group">


### PR DESCRIPTION
Removed umb-headline class as it is not necessary. Umbraco only use it
for editable fields. Adjusted the columns to give more space for title.
Mostly the title need most space and only a few buttons on the right.