### PR TITLE
Consistency filters and type="text"

### DIFF
--- a/src/Merchello.Web.UI.Client/src/views/customers/customerlist.html
+++ b/src/Merchello.Web.UI.Client/src/views/customers/customerlist.html
@@ -21,7 +21,7 @@
             <div class="merchello-pane">
                 <form class="form-horizontal row-fluid">
                     <!-- Number of Customer Per Page -->
-                    <div class="controls pull-right" data-ng-show="customers.length > 0">
+                    <div class="controls pull-right" style="margin-left: 0;" data-ng-show="customers.length > 0">
                         <span style="line-height: 30px; margin-left: -2em;">Show:&nbsp;</span>
                         <select name="limitSelect" class="form-control span9 col-xs-9" data-ng-model="limitAmount" data-ng-change="limitChanged(limitAmount)">
                             <option value="10">10</option>
@@ -31,12 +31,12 @@
                         </select>
                     </div>
                     <!-- Customer Filters -->
-                    <div class="form-group control-group">
-                        <label for="customerFilter" class="col-xs-2 control-label">Filter Customers:</label>
-                        <div class="col-xs-10 controls">
-                            <input id="customerFilter" class="form-control span6" name="customerFilter" data-ng-model="filterText" placeholder="Type a customer's name or email." />
+                    <div class="form-group control-group span10">
+                        <label class="control-label" for="customerFilter">Filter Customers:</label>
+                        <div class="controls">
+                            <input type="text" id="customerFilter" class="form-control span8" name="customerFilter" data-ng-model="filterText" placeholder="Type a customer's name or email." />
                             <!-- ACTION: Customer Filter -->
-                            <button type="submit" class="btn" data-ng-click="loadCustomers(filterText)">Filter</button>
+                            <button type="submit" id="customersFilterGo" class="btn" data-ng-click="loadCustomers(filterText)">Filter</button>
                         </div>
                     </div>
                 </form>

--- a/src/Merchello.Web.UI.Client/src/views/products/productlist.html
+++ b/src/Merchello.Web.UI.Client/src/views/products/productlist.html
@@ -21,26 +21,22 @@
         <merchello-panel>
             <div class="merchello-pane">
                 <form class="form-horizontal row-fluid">
-
-                        <div class="controls pull-right" data-ng-show="products.length > 0">
-                            <span style="line-height: 30px; margin-left: -2em;">Show:&nbsp;</span>
-                            <select name="limitSelect" class="form-control span9 col-xs-9" data-ng-model="limitAmount" data-ng-change="limitChanged(limitAmount)">
-                                <option value="10">10</option>
-                                <option value="25">25</option>
-                                <option value="50">50</option>
-                                <option value="100">100</option>
-                            </select>
-                        </div>
-
-
-                    <div class="form-group control-group">
-                        <div class="control-label">
-                            <a data-ng-click="filterAction = !filterAction" class="btn" data-ng-show="false"><localize key="merchelloOrder_filter" /></a>
-                        </div>
-                        <div class="col-xs-10 controls">
-                            <input id="productFilter" class="form-control span6" name="productFilter" data-ng-model="filterText" localize="placeholder" placeholder="@placeholders_filter" />
+                    <div class="controls pull-right" style="margin-left: 0;" data-ng-show="products.length > 0">
+                        <span style="line-height: 30px; margin-left: -2em;">Show:&nbsp;</span>
+                        <select name="limitSelect" class="form-control span9 col-xs-9" data-ng-model="limitAmount" data-ng-change="limitChanged(limitAmount)">
+                            <option value="10">10</option>
+                            <option value="25">25</option>
+                            <option value="50">50</option>
+                            <option value="100">100</option>
+                        </select>
+                    </div>
+                    <div class="form-group control-group span10">
+                        <label class="control-label" for="productFilter">Filter Products:</label>
+                        <div class="controls">
+                            <input type="text" id="productFilter" class="form-control span8" name="productFilter" data-ng-model="filterText" localize="placeholder" placeholder="@placeholders_filter" />
                             <!-- ACTION: Filter Sales  -->
-                            <button id="salesFilterGo" class="btn" data-ng-click="getFilteredProducts(filterText)"><localize key="merchelloGeneral_filter" /></button>
+                            <button type="submit" id="productsFilterGo" class="btn" data-ng-click="getFilteredProducts(filterText)"><localize key="merchelloGeneral_filter" /></button>
+                            <a data-ng-click="filterAction = !filterAction" class="btn" data-ng-show="false"><localize key="merchelloOrder_filter" /></a>
                         </div>
                     </div>
                 </form>

--- a/src/Merchello.Web.UI.Client/src/views/sales/saleslist.html
+++ b/src/Merchello.Web.UI.Client/src/views/sales/saleslist.html
@@ -21,7 +21,7 @@
             <div class="merchello-pane">
                 <form class="form-horizontal row-fluid">
                     <!-- Number of Orders/Invoices Per Page -->
-                    <div class="controls pull-right" data-ng-show="invoices.length > 0">
+                    <div class="controls pull-right" style="margin-left: 0;" data-ng-show="invoices.length > 0">
                         <span style="line-height: 30px; margin-left: -2em;">Show:&nbsp;</span>
                         <select name="limitSelect" class="form-control span9 col-xs-9" data-ng-model="limitAmount" data-ng-change="limitChanged(limitAmount)">
                             <option value="10">10</option>
@@ -31,14 +31,13 @@
                         </select>
                     </div>
                     <!-- Order Filters -->
-                    <div class="form-group control-group">
-                        <div class="control-label">
-                            <a data-ng-click="filterAction = !filterAction" class="btn" data-ng-show="false"><localize key="merchelloOrder_filter" /></a>
-                        </div>
-                        <div class="col-xs-10 controls">
-                            <input id="salesFilter" class="form-control span6" name="salesFilter" data-ng-model="filterText" localize="placeholder" placeholder="Search by invoice number or customer name" />
+                    <div class="form-group control-group span10">
+                        <label class="control-label" for="salesFilter">Filter Orders:</label>
+                        <div class="controls">
+                            <input type="text" id="salesFilter" class="form-control span8" name="salesFilter" data-ng-model="filterText" localize="placeholder" placeholder="Search by invoice number or customer name" />
                             <!-- ACTION: Filter Sales  -->
                             <button id="salesFilterGo" class="btn" data-ng-click="filterWithWildcard(filterText)"><localize key="merchelloGeneral_filter" /></button>
+                            <a data-ng-click="filterAction = !filterAction" class="btn" data-ng-show="false"><localize key="merchelloOrder_filter" /></a>
                         </div>
                     </div>
                 </form>


### PR DESCRIPTION
Made some changes to make the filter input fields for Products, Sales
and Customers to be consistency and added missing type="text" attribute.
Now I also can see the whole placeholder text in Sales Filter on my
"small" screen - 1366 x 768 px.