### PR TITLE
Updated Invoice Builder Chain to allow invoice to treat discount amounts the same way as the basket

### DIFF
--- a/src/Merchello.Core/Builders/InvoiceBuilderChain.cs
+++ b/src/Merchello.Core/Builders/InvoiceBuilderChain.cs
@@ -86,7 +86,7 @@
 
             // total the invoice
             decimal converted;
-            attempt.Result.Total = Math.Round(decimal.TryParse((charges - discounts).ToString(CultureInfo.InvariantCulture), NumberStyles.AllowDecimalPoint, CultureInfo.InvariantCulture.NumberFormat, out converted) ? converted : 0, 2);
+            attempt.Result.Total = Math.Round(decimal.TryParse((charges + discounts).ToString(CultureInfo.InvariantCulture), NumberStyles.AllowDecimalPoint, CultureInfo.InvariantCulture.NumberFormat, out converted) ? converted : 0, 2);
                
             return attempt;
         }


### PR DESCRIPTION
Currently the basket code uses plus to add discounts to the totals while the invoice code uses minus. This meant that it was difficult to calculate tax when there were discounts on the basket. 