### PR TITLE
Allow custom basket line items in the paypal pament details

### DIFF
--- a/Plugin/Payments/PayPal/src/Merchello.Plugin.Payments.PayPal/PayPalPaymentProcessor.cs
+++ b/Plugin/Payments/PayPal/src/Merchello.Plugin.Payments.PayPal/PayPalPaymentProcessor.cs
@@ -137,7 +137,7 @@ namespace Merchello.Plugin.Payments.PayPal
 							Phone = address.Phone
 						};
 					}
-				} else if (item.LineItemTfKey == Merchello.Core.Constants.TypeFieldKeys.LineItem.ProductKey) {
+				} else {
 					var paymentItem = new PaymentDetailsItemType {
 						Name = item.Name,
 						ItemURL = (articleBySkuPath.IsEmpty() ? null : articleBySkuPath + item.Sku),


### PR DESCRIPTION
I need this payment method to allow Custom basket line items, so I have removed the LineItem.ProductKey type restriction in this method so the paypal payment details object can be created correctly.