### PR TITLE
Updated tax provider to include the tax rate in line item extended data

### DIFF
--- a/src/Merchello.Core/Gateways/Taxation/TaxableLineItemVisitor.cs
+++ b/src/Merchello.Core/Gateways/Taxation/TaxableLineItemVisitor.cs
@@ -48,8 +48,16 @@
         public void Visit(ILineItem lineItem)
         {
             if (!lineItem.ExtendedData.GetTaxableValue()) return;
-            
-            lineItem.ExtendedData.SetValue(Constants.ExtendedDataKeys.LineItemTaxAmount, (lineItem.TotalPrice * this._taxRate).ToString(CultureInfo.InvariantCulture));
+
+            if (lineItem.LineItemType == LineItemType.Discount)
+            {
+                lineItem.ExtendedData.SetValue(Constants.ExtendedDataKeys.LineItemTaxAmount, (-lineItem.TotalPrice * this._taxRate).ToString(CultureInfo.InvariantCulture));
+            }
+            else
+            {
+                lineItem.ExtendedData.SetValue(Constants.ExtendedDataKeys.LineItemTaxAmount, (lineItem.TotalPrice * this._taxRate).ToString(CultureInfo.InvariantCulture));
+            }
+            lineItem.ExtendedData.SetValue(Constants.ExtendedDataKeys.BaseTaxRate, this._taxRate.ToString());
             _lineItems.Add(lineItem);
         }
     }


### PR DESCRIPTION
The tax provider was not marking the tax rate against line items. I believe that the ExtendedDataKeys.BaseTaxRate is the correct place to put it. Please correct me if I'm wrong!