### PR TITLE
Updated tax provider to include the tax rate in line item extended data

### DIFF
--- a/src/Merchello.Core/Gateways/Taxation/TaxableLineItemVisitor.cs
+++ b/src/Merchello.Core/Gateways/Taxation/TaxableLineItemVisitor.cs
@@ -56,7 +56,7 @@
             {
                 lineItem.ExtendedData.SetValue(Constants.ExtendedDataKeys.LineItemTaxAmount, (lineItem.TotalPrice * this._taxRate).ToString(CultureInfo.InvariantCulture));
             }
-            
+            lineItem.ExtendedData.SetValue(Constants.ExtendedDataKeys.BaseTaxRate, this._taxRate.ToString());
             _lineItems.Add(lineItem);
         }
     }


### PR DESCRIPTION
The tax provider was not marking the tax rate against line items.