### PR TITLE
fixed js typo bug in export orders.

### DIFF
--- a/Plugin/Reports/ExportOrders/src/Merchello.Plugin.Reports.ExportOrders/App_Plugins/Merchello.ExportOrders/exportOrders.controller.js
+++ b/Plugin/Reports/ExportOrders/src/Merchello.Plugin.Reports.ExportOrders/App_Plugins/Merchello.ExportOrders/exportOrders.controller.js
@@ -44,7 +44,7 @@
          */
         function exportOrders(filterStartDate, filterEndDate) {
             // prevent exporting more orders until current order is complete
-            if (loaded == false) {
+            if ($scope.loaded == false) {
                 return;
             }
 


### PR DESCRIPTION
This bug will prevent export orders from working. I broke it on my last commit. Fixed here.