### PR TITLE
Check if paymentMethod exists

### DIFF
--- a/src/Merchello.Core/Sales/SalePreparationBase.cs
+++ b/src/Merchello.Core/Sales/SalePreparationBase.cs
@@ -245,7 +245,8 @@
         public IPaymentMethod GetPaymentMethod()
         {
             var paymentMethodKey = _customer.ExtendedData.GetPaymentMethodKey();
-            return paymentMethodKey.Equals(Guid.Empty) ? null : _merchelloContext.Gateways.Payment.GetPaymentGatewayMethodByKey(paymentMethodKey).PaymentMethod;
+            var paymentMethod = _merchelloContext.Gateways.Payment.GetPaymentGatewayMethodByKey(paymentMethodKey);
+            return paymentMethodKey.Equals(Guid.Empty) || paymentMethod == null ? null : paymentMethod.PaymentMethod;
         }
 
         /// <summary>


### PR DESCRIPTION
If customer add a payment method and after a seller will remove the payment method, the application will crash