### PR TITLE
Little bug on creating `issues` model

### DIFF
--- a/src/Merchello.Web.UI/App_Plugins/Merchello/js/merchello.models.js
+++ b/src/Merchello.Web.UI/App_Plugins/Merchello/js/merchello.models.js
@@ -3968,7 +3968,7 @@ angular.module('merchello.models').factory('notificationGatewayProviderDisplayBu
                             invoices.invoiceStatus = invoiceStatusDisplayBuilder.transform(jsonResult.invoiceStatus);
                             invoices.items = invoiceLineItemDisplayBuilder.transform(jsonResult.items);
                             invoices.orders = orderDisplayBuilder.transform(jsonResult.orders);
-                            invoices.curreny = currencyDisplayBuilder.transform(jsonResult.currency);
+                            invoices.currency = currencyDisplayBuilder.transform(jsonResult.currency);
                         }
                         return invoices;
                     }


### PR DESCRIPTION
I found a little bug on creating `issues` model. The model create `curreny` property instead of `currency`.  
The same bug exists in 1.9.0 version also.