### PR TITLE
Update Danish language xml

### DIFF
--- a/src/Merchello.Web.UI.Client/src/config/lang/da.xml
+++ b/src/Merchello.Web.UI.Client/src/config/lang/da.xml
@@ -1,11 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8" standalone="yes"?>
 <language alias="da_dk" intName="Danish" localName="Dansk" lcid="" culture="da-DK">
   <area alias="merchelloButtons">
-    <key alias="void">Void</key>
-    <key alias="refund">Refund</key>
-    <key alias="delete">Delete</key>
-    <key alias="save">Save</key>
-    <key alias="select">Select</key>
+    <key alias="void">Annuller</key>
+    <key alias="refund">Refundér</key>
+    <key alias="delete">Slet</key>
+    <key alias="save">Gem</key>
+    <key alias="select">Vælg</key>
   </area>
   <area alias="merchelloHeadline">
     <key alias="catalog">Katalog</key>
@@ -19,33 +19,33 @@
     <key alias="barcode">Stregkode</key>
     <key alias="manufacturer">Forhandler</key>
     <key alias="manufacturerModel">Forhandler model nr.</key>
-    <key alias="variantInfo">Product Information</key>
+    <key alias="variantInfo">Produktinformation</key>
     <key alias="variantOptions">Varianter</key>
     <!-- TODO: Figure out context - is it right? -->
-    <key alias="downloads">Digitale Downloads</key>
-    <key alias="optionName">Mulighed navn</key>
+    <key alias="downloads">Digitale downloads</key>
+    <key alias="optionName">Navn på valgmulighed</key>
     <!-- TODO: Figure out context - is it right? -->
-    <key alias="optionValues">Mulighed værdier</key>
+    <key alias="optionValues">Værdier for valgmuligheden</key>
     <!-- TODO: Figure out context - is it right? -->
     <!-- actions -->
-    <key alias="newProduct">Nyt Produkt</key>
+    <key alias="newProduct">Nyt produkt</key>
     <key alias="createProduct">Opret et produkt</key>
-    <key alias="createProductSub">Navn (Ovenfor), Pris, og SKU er obligatoriske felter. De øvrige felter er valgfrie.</key>
+    <key alias="createProductSub">Navn (ovenfor), pris og SKU er obligatoriske felter. De øvrige felter er valgfrie.</key>
     <key alias="newVariant">Ny variant</key>
     <key alias="newVariantFor">Ny variant til</key>
     <key alias="newVariantOn">Dette bliver en ny variant på</key>
     <key alias="addVariant">Tilføj en variant</key>
     <key alias="addVariantSub">Dette bliver en ny variant på produktet %0%.</key>
-    <key alias="addOption">Tilføj mulighed</key>
+    <key alias="addOption">Tilføj valgmulighed</key>
     <!-- TODO: Figure out context - is it right? -->
-    <key alias="addOptions">Tilføj muligheder til varianten og auto-udfyld ekstra varianter for hver mulighed</key>
+    <key alias="addOptions">Tilføj muligheder til varianten og auto-udfyld ekstra varianter for hver valgmulighed</key>
     <!-- TODO: Figure out context - is it right? -->
     <key alias="deleteProduct">Slet produkt</key>
     <key alias="deleteVariant">Slet variant</key>
     <key alias="configVariant">Konfigurér denne variant</key>
     <key alias="selectVariantOptions">Vælg de varianter/muligheder der skal oprettes.</key>
     <!-- TODO: Figure out context - is it right? -->
-    <key alias="addFile">Tilføj en fil på din produkt variant</key>
+    <key alias="addFile">Tilføj en fil på din produktvariant</key>
     <key alias="trackInventory">Spor lagerstatus for denne variant</key>
     <key alias="setInventoryPreferences">Vælg hvordan udsolgte varer håndteres og justér varekatalog for denne variant.</key>
     <!-- phrases -->
@@ -60,76 +60,84 @@
     <key alias="noProduct">Du har ingen produkter.</key>
     <key alias="newProductPrompt">Vil du oprette et produkt? Så klik på knappen "Nyt produkt".</key>
     <key alias="limitSelect">Antal produkter der skal vises</key>
-    <key alias="mustUniqueSku">Skal have en unik SKU</key>
-    <key alias="inventoryWarning"><![CDATA[<p>Vigtigt: Hvis du vælger at spore lagerbeholdningen skal det opsættes manuelt for hver enkelt variant (Herunder), når produktet er gemt. Du kan opsætte en basis lagerbeholdning som tilknyttes <strong>alle varianter</strong> her.</p>]]></key>
+    <key alias="mustUniqueSku">Skal have et unikt SKU</key>
+    <key alias="inventoryWarning"><![CDATA[<p>Vigtigt: Hvis du vælger at spore lagerbeholdningen, skal det opsættes manuelt for hver enkelt variant (herunder), når produktet er gemt. Du kan opsætte en basis lagerbeholdning, som tilknyttes <strong>alle varianter</strong> her.</p>]]></key>
     <key alias="startingInventoryWarning"><![CDATA[(Dette vil opsætte en start lagerbeholdning for <strong>alle varianter</strong> og <strong>alle lagre</strong>)]]></key>
     <!-- WHat is this?-->
-    <key alias="productOnSale">Product on sale</key>
-    <key alias="toggleOnSale">On Sale</key>
-    <key alias="toggleAvailable">Available</key>
-    <key alias="isOnSale">This variant is on sale</key>
-    <key alias="isAvailable">This variant is available to purchase</key>
+    <key alias="productOnSale">Produkt på tilbud</key>
+    <key alias="toggleOnSale">På tilbud</key>
+    <key alias="toggleAvailable">Tilgængelig</key>
+    <key alias="isOnSale">Denne variant er på tilbud</key>
+    <key alias="isAvailable">Denne variant er tilgængelig til køb</key>
   </area>
   <area alias="merchelloOrder">
     <!-- things -->
+    <key alias="invoice">Faktura</key>
+    <key alias="invoiceNumber">Faktura #</key>
     <key alias="order">Ordre</key>
     <key alias="orders">Ordrer</key>
-    <key alias="orderNumber">Ordre nummer</key>
+    <key alias="orderNumber">Ordre #</key>
     <key alias="paymentStatus">Betalingsstatus</key>
     <key alias="fulfillmentStatus">Fulfillment Status</key>
     <!-- TODO: Figure out context - is it right? -->
-    <key alias="lineItems"> Ordrelinier</key>
-    <key alias="orderName">[Ordre navn]</key>
+    <key alias="lineItems">Ordrelinier</key>
+    <key alias="orderName">[Ordrenavn]</key>
     <!-- actions -->
     <key alias="filter">Filtrér ordre</key>
-    <key alias="capturePayment">Capture Payment</key>
+    <key alias="capturePayment">Træk betaling</key>
     <!-- TODO: Figure out context - is it right? -->
     <key alias="processPayment">Gennemfør betaling</key>
+    <key alias="createOrder">Opret ordre</key>
+    <key alias="sales">Salg</key>
+    <key alias="saleInformation">Salgsinformation</key>
+    <!-- actions -->
+    <key alias="filter">Filter Invoices</key>
+    <key alias="addDateFilters">Tilføj dato filtrer</key>
+    <key alias="removeDateFilters">Fjern dato filtrer</key>
+    <key alias="capturePayment">Capture Payment</key>
+    <key alias="processPayment">Process Payment</key>
+    <key alias="voidPayment">Annuller betaling</key>
+    <key alias="refundPayment">Refundér betaling</key>
+    <key alias="voidPaymentConfirmMessage">Er du sikker du vil refundere denne betaling?</key>
     <!-- phrases -->
     <key alias="invoicesPerPage">Fakturaer / Side</key>
-    <key alias="noOrders">Der er ingen ordrer.</key>
+    <key alias="noOrders">Du har ingen ordrer.</key>
     <key alias="attentionRequired">Der er ordrer der skal behandles</key>
     <key alias="paymentExpirationWarning">Du modtager muligvis ikke betaling, hvis tilladelsen udløber.</key>
     <key alias="processedBy">Behandlet af</key>
-    <key alias="resetFilters">Reset Filters</key>
-    <key alias="invoice">Invoice</key>
-    <key alias="invoiceNumber">Invoice #</key>
-    <key alias="createOrder">Create Order</key>
-    <key alias="sales">Sales</key>
-    <key alias="saleInformation">Sale Information</key>
-    <key alias="addDateFilters">Add date filters</key>
-    <key alias="removeDateFilters">Remove date filters</key>
-    <key alias="voidPayment">Void Payment</key>
-    <key alias="refundPayment">Refund Payment</key>
-    <key alias="voidPaymentConfirmMessage">Are you sure you would like to void this payment?</key>
-    <key alias="refundMethod">Refund method</key>
+    <key alias="refundMethod">Tilbagebetalingsmetode</key>
+    <key alias="resetFilters">Nulstil filtrer</key>
+    <key alias="archiveSales">Arkivér salg</key>
+    <key alias="unarchiveSales">Annuller arkivering af salg</key>
+    <key alias="noSalesYet">Du har ingen salg endnu</key>
+    <key alias="butSoonYouWill">men det vil du snart have!</key>
   </area>
   <area alias="merchelloOrderView">
     <!-- things -->
     <key alias="invoiceNumber">Faktura nummer</key>
-    <key alias="customerInformation">Kunde information</key>
+    <key alias="customerInformation">Kundeinformation</key>
     <key alias="shippingAddress">Leveringsadresse</key>
-    <key alias="billingAddress">Faktura adresse</key>
-    <key alias="orderInformation">Ordre information</key>
+    <key alias="billingAddress">Faktureringsadresse</key>
+    <key alias="orderInformation">Ordreinformation</key>
     <!-- actions -->
     <!-- phrases -->
-    <key alias="billingAndShippingAddressHelper">Betaling -og leveringsadresser</key>
+    <key alias="billingAndShippingAddressHelper">Betaling- og leveringsadresser</key>
     <key alias="orderInformationHelper"><![CDATA[Ordrelinier og omkostninger]]></key>
     <key alias="captureUpTo">Indløs op til</key>
     <key alias="salesTax">Moms</key>
-    <key alias="authorized"> Autoriseret</key>
-    <key alias="captured">Captured</key>
-    <key alias="paymentHistory"> Betalingshistorik</key>
-    <key alias="paymentHistoryHelper">Status records for one or more payments</key>
+    <key alias="authorized">Autoriseret</key>
+    <key alias="captured">Trukket</key>
+    <key alias="paymentHistory">Betalingshistorik</key>
+    <key alias="paymentHistoryHelper">Status registreringer for en eller flere betalinger</key>
     <!-- TODO: Figure out context - is it right? -->
     <key alias="paymentProcessedBy">Betaling gennemført af:</key>
-    <key alias="saleHistory">Sale History</key>
-    <key alias="resetFilters">Reset Filters</key>
+    <key alias="saleHistory">Salgshistorik</key>
+    <key alias="resetFilters">Nulstil filtrer</key>
   </area>
   <area alias="merchelloFulfillShipment">
     <!-- phrases -->
     <key alias="fulfillManually">Udfyld manuelt</key>
-    <key alias="createShipment">Create Shipment</key>
+    <key alias="createShipment">Opret forsendelsesmetode</key>
   </area>
   <area alias="merchelloWarehouse">
     <!-- things -->
@@ -139,21 +147,21 @@
     <key alias="lowCount">Lavt antal</key>
     <!-- actions -->
     <!-- phrases -->
-    <key alias="location">Location</key>
+    <key alias="location">Lokation</key>
   </area>
   <area alias="merchelloShipping">
     <!-- things -->
     <key alias="shipping">Forsendelse</key>
-    <key alias="info">Forsendelses information</key>
-    <key alias="weight">Vægt&gt;</key>
+    <key alias="info">Forsendelsesinformation</key>
+    <key alias="weight">Vægt</key>
     <key alias="dimensions">Dimensioner</key>
     <!-- actions -->
-    <key alias="setVars">Opsæt forsendelses variabler: Vægt, og dimensioner</key>
+    <key alias="setVars">Opsæt forsendelsesvariabler: Vægt og dimensioner</key>
     <!-- phrases -->
     <key alias="editWarehouseHelper">Redigér dit lager</key>
     <key alias="editWarehouse">Redigér lager</key>
-    <key alias="shippingMethods">Forsendelses muligheder</key>
-    <key alias="shippingMethodsHelper">Tilføj forsendelses muligheder til eksisterende regioner eller opret en ny region</key>
+    <key alias="shippingMethods">Forsendelsesmuligheder</key>
+    <key alias="shippingMethodsHelper">Tilføj forsendelsesmuligheder til eksisterende regioner eller opret en ny region</key>
     <key alias="addCountry">Tilføj et land</key>
   </area>
   <area alias="merchelloInventory">
@@ -166,16 +174,16 @@
   </area>
   <area alias="merchelloPlaceholders">
     <key alias="enterProduct">Angiv et produkt navn</key>
-    <key alias="enterOrder">Skriv et odre nummer eller navn...</key>
+    <key alias="enterOrder">Skriv et ordrenummer eller navn...</key>
     <key alias="addStyle">Tilføj type...</key>
-    <key alias="enterOffer">Enter a name for the offer</key>
+    <key alias="enterOffer">Indtast et navn for rabatten</key>
   </area>
   <area alias="merchelloGeneral">
     <key alias="apply">Ansøg</key>
     <key alias="price">Pris</key>
     <key alias="customer">Kunde</key>
     <key alias="total">Total</key>
-    <key alias="salePrice">Salgs pris</key>
+    <key alias="salePrice">Salgspris</key>
     <key alias="filter">Filter</key>
     <key alias="filterBy">Sorter efter</key>
     <key alias="chooseMedia">Vælg medier</key>
@@ -187,33 +195,33 @@
     <key alias="shipment">Forsendelse</key>
     <key alias="sku">SKU</key>
     <key alias="quantity">Antal</key>
-    <key alias="fulfill"> Udfyld</key>
-    <key alias="status"> Status</key>
-    <key alias="type"> Type</key>
-    <key alias="amount"> Beløb</key>
+    <key alias="fulfill">Udfyld</key>
+    <key alias="status">Status</key>
+    <key alias="type">Type</key>
+    <key alias="amount">Beløb</key>
     <key alias="via">Gennem</key>
     <key alias="options">Muligheder</key>
     <key alias="select">Vælg</key>
     <key alias="all">Alle</key>
     <key alias="none">Ingen</key>
-    <key alias="expired">Expired</key>
+    <key alias="expired">Udløbet</key>
   </area>
   <area alias="merchelloSettings">
     <key alias="storeDefaults">Standard indstillinger for butik</key>
     <key alias="setDefaultSettingsHelper">Opsæt standard instillingerne</key>
     <key alias="currency">Valuta</key>
-    <key alias="dateFormat">Dato format</key>
-    <key alias="startingOrderNumber">Startende ordre nummer</key>
+    <key alias="dateFormat">Datoformat</key>
+    <key alias="startingOrderNumber">Startende ordrenummer</key>
     <key alias="timeFormat">Format for dato/tid</key>
-    <key alias="startingInvoiceNumber">Startende faktura nummer</key>
-    <key alias="startingShipmentNumber">Starting Shipment No.</key>
+    <key alias="startingInvoiceNumber">Startende fakturanummer</key>
+    <key alias="startingShipmentNumber">Startende forsendelsesnummer</key>
     <key alias="catalogDefaults">Standard Katalog</key>
     <key alias="catalogDefaultsHelper">Opsæt standard katelog enheders (produkt) muligheder. Kan ændres pr. enhed senere.</key>
     <key alias="globalTaxable">Alle enheder er momspligtige</key>
     <key alias="globalShippable">Alle enheder kan afsendes</key>
     <key alias="globalTrackInventory"><![CDATA[Track inventory for all items & variants]]></key>
     <key alias="globalShippingIsTaxable">Der skal betales moms af forsendelsesomkostningerne</key>
-    <key alias="unitSystem">Unit System</key>
+    <key alias="unitSystem">Enhedssystem</key>
   </area>
   <area alias="merchelloShippingCountry">
     <key alias="addCountry">Tilføj et land</key>
@@ -227,9 +235,9 @@
     <key alias="streetAddress">Adresse</key>
     <key alias="extendedAddress">Adresse 2</key>
     <key alias="city">By</key>
-    <key alias="stateProvince">Stat/Provins</key>
-    <key alias="zip"> Postnummer</key>
-    <key alias="country"> Land</key>
+    <key alias="stateProvince">Stat/provins</key>
+    <key alias="zip">Postnummer</key>
+    <key alias="country">Land</key>
     <key alias="selectCountry">Vælg land</key>
     <key alias="makePrimaryWarehouse">Gør dette til mit primære lager</key>
     <key alias="addWarehouse">Tilføj et lager</key>
@@ -249,11 +257,11 @@
     <key alias="provider">Udbyder</key>
     <key alias="addProvider">Tilføj en udbyder</key>
     <key alias="selectProvider">Vælg din udbyder</key>
-    <key alias="selectResource">Vælg din resource</key>
+    <key alias="selectResource">Vælg din kilde</key>
   </area>
   <area alias="merchelloShippingHistory">
-    <key alias="shipmentHistory">Forsendelses historik</key>
-    <key alias="shipmentHistoryHelper">Status records for one or more shipments</key>
+    <key alias="shipmentHistory">Forsendelseshistorik</key>
+    <key alias="shipmentHistoryHelper">Status registreringer for en eller flere forsendelser</key>
     <!--TODO: Figure out context -->
     <key alias="shipment">Forsendelse</key>
     <key alias="trackingNumber">Sporingsnummer</key>
@@ -261,17 +269,17 @@
   <area alias="merchelloTaxation">
     <key alias="taxation">Afgifter</key>
     <key alias="taxMethods">Afgifts metoder</key>
-    <key alias="taxMethodsHelper">Opsæt en flad beskatning/Afgift til dine forsendelesregioner</key>
+    <key alias="taxMethodsHelper">Opsæt en flad beskatning/afgift til dine forsendelesregioner</key>
   </area>
   <area alias="merchelloNotifications">
     <key alias="notifications">Notifikationer</key>
     <key alias="addNotification">Tilføj notifikation</key>
   </area>
   <area alias="merchelloNotificationsEdit">
-    <key alias="emailTemplate">Email skabelon</key>
-    <key alias="emailTemplateHelper">Redigér notifikations skabelon</key>
+    <key alias="emailTemplate">E-mail skabelon</key>
+    <key alias="emailTemplateHelper">Redigér notifikationsskabelon</key>
     <key alias="emailTemplateEditBody">Redigér brødteksten</key>
-    <key alias="notificationSettings">Notifikations indstillinger</key>
+    <key alias="notificationSettings">Notifikationsindstillinger</key>
     <key alias="notificationSettingsHelper">Vælg hvem din notifikation skal sendes til og hvornår</key>
     <key alias="description">Beskrivelse</key>
     <key alias="attachedEvent">Vedhæftet begivenhed</key>
@@ -290,7 +298,7 @@
     <key alias="merchelloNotificationsDelete_deleteNotification">Slet en notifikations metode</key>
   </area>
   <area alias="merchelloNotificationsMessage">
-    <add alias="replyTo">Reply to</add>
+    <add alias="replyTo">Svar til</add>
     <key alias="addEditMessage">Tilføj/Redigér notifikations besked</key>
     <key alias="attachedEvent">Vedhæftet begivenhed</key>
     <key alias="fromEmail"><![CDATA[Fra e-mail adresse<small>(i.e. confirmation@yourdomain.com)</small>]]></key>
@@ -305,7 +313,7 @@
     <key alias="emailCustomer">E-mail kunde</key>
   </area>
   <area alias="merchelloGatewayProvider">
-    <key alias="host">Host</key>
+    <key alias="host">Vært</key>
     <key alias="enableSSL">Aktivér SSL</key>
     <key alias="encryptProviderConfiguration"> Kryptér udbyder konfiguration</key>
     <key alias="gatewayProvider">Gateway udbydere</key>
@@ -338,84 +346,84 @@
     <key alias="deleteConfirmation">Er du sikker på du vil fjerne betalingsmetoden?</key>
   </area>
   <area alias="merchelloProductEdit">
-    <key alias="enterProductName">Skriv et produkt navn</key>
+    <key alias="enterProductName">Indtast et produktnavn</key>
     <key alias="dragAndReorder">Træk for at sortere muligheder og varianter</key>
     <key alias="reorderVariants">Sorter varianter</key>
-    <key alias="dragAndReorderHelper">Hvis du sorterer dine muligheder og varianter vil det ændre den rækkefølge de fremstår i på din webshop. Træk dine muligheder (f.eks. størrelse eller type) vertikalt og varianter (f.eks. kvinder eller lille) horizontalt.</key>
+    <key alias="dragAndReorderHelper">Hvis du sorterer dine muligheder og varianter vil det ændre den rækkefølge de fremstår i på din webshop. Træk dine muligheder (f.eks. størrelse eller type) vertikalt og varianter (f.eks. kvinder eller lille) horisontalt.</key>
     <key alias="changePrices">Ret priser</key>
     <key alias="updateInventory">Opdater lagerbehandling</key>
-    <key alias="duplicateVariant"> Duplikér variant</key>
+    <key alias="duplicateVariant">Duplikér variant</key>
     <key alias="inAnother">I en anden</key>
     <key alias="editOptions">Redigér muligheder</key>
     <key alias="editOptionsHelper">Redigér/Tilføj muligheder, som automatisk opdaterer dine varianter</key>
-    <key alias="optionName">Mulighed navn</key>
+    <key alias="optionName">Navn på valgmulighed</key>
     <key alias="optionNameHelper">(f.eks. størrelse, type, farve)</key>
-    <key alias="optionValue">Mulighed værdier</key>
+    <key alias="optionValue">Værdier for valgmulighed</key>
     <key alias="optionValueHelper">(f.eks. rød, grøn, blå)</key>
     <key alias="addStyle">Tilføj type...</key>
-    <key alias="addAnotherOption">Tilføj ny mulighed</key>
-    <key alias="variantInformation">Variant information</key>
+    <key alias="addAnotherOption">Tilføj ny valgmulighed</key>
+    <key alias="variantInformation">Variantinformation</key>
     <key alias="variantInformationHelper">Redigér varianter på dette produkt.</key>
     <key alias="selectProduct">Vælg produkt...</key>
     <key alias="selectMerchelloProduct">Vælg Merchello Produkt</key>
     <key alias="selectYourProduct">Vælg dit produkt</key>
-    <key alias="toggleAvailable">Toggle Available</key>
-    <key alias="toggleOnSale">Toggle On Sale</key>
-    <key alias="removeProduct">Disconnect This Product</key>
+    <key alias="toggleAvailable">Skift "tilgængelighed"</key>
+    <key alias="toggleOnSale">Skift "på tilbud"</key>
+    <key alias="removeProduct">Frakobl dette produkt</key>
     <key alias="itemLocation">Item Location</key>
   </area>
   <area alias="merchelloAuditLogs">
-    <key alias="notificationShipping">Shipping confirmation email sent to %0%</key>
-    <key alias="notificationSalesConfirmation">Sales confirmation email sent to %0%</key>
-    <key alias="paymentCaptured">We successfully captured %0% %1%</key>
-    <key alias="paymentAuthorize">We were authorized to capture %0% %1%</key>
-    <key alias="paymentVoided">Payment was voided</key>
-    <key alias="paymentDeclined">Payment was declined</key>
-    <key alias="paymentRefunded">We refunded %0% %1% of a payment</key>
-    <key alias="invoiceDeleted">Invoice %0% was deleted</key>
-    <key alias="paymentDeleted">Payment was deleted</key>
-    <key alias="invoiceCreated">Sale was made. Invoice %0%</key>
-    <key alias="invoiceStatusChanged">Invoice was marked %0%</key>
-    <key alias="orderCreated">Order %0% was created</key>
-    <key alias="shipmentCreated">Shipment was created with %0% line items</key>
-    <key alias="shipmentStatusChanged">Shipment status was changed to %0%</key>
+    <key alias="notificationShipping">Forsendelse bekræftelse e-mail sendt til %0%</key>
+    <key alias="notificationSalesConfirmation">Salg bekræftelse e-mail sendt til %0%</key>
+    <key alias="paymentCaptured">Vi har trukket %0% %1%</key>
+    <key alias="paymentAuthorize">Vi fik tilladelse til at trække %0% %1%</key>
+    <key alias="paymentVoided">Betaling blev annulleret</key>
+    <key alias="paymentDeclined">Betaling blev afvist</key>
+    <key alias="paymentRefunded">Vi refunderede %0% %1% af en betaling</key>
+    <key alias="invoiceDeleted">Faktura %0% blev slettet</key>
+    <key alias="paymentDeleted">Betaling blev slettet</key>
+    <key alias="invoiceCreated">Salg blev foretaget. Faktura %0%</key>
+    <key alias="invoiceStatusChanged">Faktura blev markeret %0%</key>
+    <key alias="orderCreated">Ordre %0% blev oprettet</key>
+    <key alias="shipmentCreated">Forsendelse blev oprettet med %0% linjeposter</key>
+    <key alias="shipmentStatusChanged">Status på forsendelse blev ændret til %0%</key>
   </area>
   <area alias="merchelloMarketing">
-    <key alias="campaigns">Marketing Campaigns</key>
-    <key alias="activities">Activities</key>
-    <key alias="btnNewCampaign">New Campaign</key>
-    <key alias="btnDeleteCampaign">Delete</key>
-    <key alias="enterCampaignName">Enter a name for the campaign</key>
-    <key alias="campaignInfo">Campaign Settings</key>
-    <key alias="configCampaign">Configure this marketing campaign</key>
-    <key alias="isActive">Is active</key>
-    <key alias="currentOffers">Current Offers</key>
-    <key alias="offerCode">Offer Code</key>
-    <key alias="newOffer">New Offer</key>
-    <key alias="noOffer">No current offers</key>
+    <key alias="campaigns">Marketing kampagner</key>
+    <key alias="activities">Aktiviteter</key>
+    <key alias="btnNewCampaign">Ny kampagne</key>
+    <key alias="btnDeleteCampaign">Slet</key>
+    <key alias="enterCampaignName">Indtast et navn for kampagnen</key>
+    <key alias="campaignInfo">Kampagneindstillinger</key>
+    <key alias="configCampaign">Konfigurér denne marketing kampagne</key>
+    <key alias="isActive">Er aktiv</key>
+    <key alias="currentOffers">Aktuelle tilbud</key>
+    <key alias="offerCode">Kode for tilbud</key>
+    <key alias="newOffer">Nyt tilbud</key>
+    <key alias="noOffer">Ingen aktuelle tilbud</key>
     <key alias="newOfferPrompt">You have not offered your customers any special offers.  Why not create one?</key>
-    <key alias="offerInfo">Offer Settings</key>
-    <key alias="configOffer">Configure this offer</key>
-    <key alias="offerType">Type of Offer</key>
-    <key alias="mustUniqueOfferCode">Offer codes must be unique.</key>
-    <key alias="offerSetExpires">This offer is only valid for specific dates.</key>
-    <key alias="offerNeverExpires">Does not expire.</key>
-    <key alias="offerValidDates">Offer Valid Dates</key>
-    <key alias="offerValidDatesInfo">Set the dates for which this offer is valid.</key>
-    <key alias="offerConstraintsInfo">Constraints</key>
+    <key alias="offerInfo">Indstilling for tilbud</key>
+    <key alias="configOffer">Konfigurér dette tilbud</key>
+    <key alias="offerType">Type af tilbud</key>
+    <key alias="mustUniqueOfferCode">Tilbudskoder skal være unikke.</key>
+    <key alias="offerSetExpires">Dette tilbud er kun gyldig for specifikke datoer.</key>
+    <key alias="offerNeverExpires">Udløber ikke.</key>
+    <key alias="offerValidDates">Gyldige datoer for tilbud</key>
+    <key alias="offerValidDatesInfo">Angiv datoerne hvor dette tilbud er gyldig.</key>
+    <key alias="offerConstraintsInfo">Restriktioner</key>
     <key alias="offerConstraintsConfig">Configure constraints associated with this offer.</key>
-    <key alias="offerRewardsInfo">Rewards</key>
-    <key alias="offerRewardsConfig">Configure rewards associated with this offer.</key>
+    <key alias="offerRewardsInfo">Belønninger</key>
+    <key alias="offerRewardsConfig">Konfigurér belønninger forbundet med dette tilbud.</key>
   </area>
   <area alias="merchelloDelete">
-    <key alias="deleteConfirmation">Delete Confirmation</key>
-    <key alias="deleteConfirmMessage">Are you sure you want to remove the item </key>
+    <key alias="deleteConfirmation">Slet bekræftelse</key>
+    <key alias="deleteConfirmMessage">Er du sikker du vil fjerne elementet</key>
   </area>
   <area alias="merchelloTableCaptions">
-    <key alias="name">Name</key>
-    <key alias="startDate">Starting</key>
-    <key alias="endDate">Ending</key>
+    <key alias="name">Navn</key>
+    <key alias="startDate">Startdato</key>
+    <key alias="endDate">Slutdato</key>
     <key alias="alias">Alias</key>
-    <key alias="active">Active</key>
+    <key alias="active">Aktiv</key>
   </area>
 </language>

--- a/src/Merchello.Web.UI.Client/src/config/lang/en.xml
+++ b/src/Merchello.Web.UI.Client/src/config/lang/en.xml
@@ -41,7 +41,7 @@
     <key alias="variant">Variant</key>
     <key alias="sku">SKU</key>
     <key alias="baseSku">Base Sku</key>
-    <key alias="barcode">Barcode</key>sel
+    <key alias="barcode">Barcode</key>
     <key alias="manufacturer">Manufacturer</key>
     <key alias="manufacturerModel">Manufacturer's Model No.</key>
     <key alias="variantInfo">Variant Information</key>
@@ -96,7 +96,7 @@
     <key alias="orderNumber">Order #</key>
     <key alias="paymentStatus">Payment Status</key>
     <key alias="fulfillmentStatus">Fulfillment Status</key>
-    <key alias="lineItems"> Line Items</key>
+    <key alias="lineItems">Line Items</key>
     <key alias="orderName">[Order Name]</key>
     <key alias="createOrder">Create Order</key>
     <key alias="sales">Sales</key>
@@ -118,6 +118,10 @@
     <key alias="processedBy">Processed by</key>
     <key alias="refundMethod">Refund method</key>
     <key alias="resetFilters">Reset Filters</key>
+    <key alias="archiveSales">Archive Sales</key>
+    <key alias="unarchiveSales">Unarchive Sales</key>
+    <key alias="noSalesYet">You have no sales yet</key>
+    <key alias="butSoonYouWill">but soon you will!</key>
   </area>
   <area alias="merchelloOrderView">
     <!-- things -->

--- a/src/Merchello.Web.UI.Client/src/config/lang/en_us.xml
+++ b/src/Merchello.Web.UI.Client/src/config/lang/en_us.xml
@@ -16,8 +16,52 @@
     <key alias="variant">Variant</key>
     <key alias="sku">SKU</key>
     <key alias="baseSku">Base Sku</key>
-    <key alias="barcode">Barcode</key>sel
-		<key alias="manufacturer">Manufacturer</key><key alias="manufacturerModel">Manufacturer's Model No.</key><key alias="variantInfo">Variant Information</key><key alias="variantOptions">Variant Options</key><key alias="downloads">Digital Downloads</key><key alias="optionName">Option Name</key><key alias="optionValues">Option Values</key><!-- actions --><key alias="newProduct">New Product</key><key alias="createProduct">Create a Product</key><key alias="createProductSub">The Name field (above), Price, and SKU are required.  Everything else is optional.</key><key alias="newVariant">New Variant</key><key alias="newVariantFor">New Variant for</key><key alias="newVariantOn">This will be a new variant on the</key><key alias="addVariant">Add a Variant</key><key alias="addVariantSub">This will be a new variant on the %0% product.</key><key alias="addOption">Add Another Option</key><key alias="addOptions">Add options to this variant and auto-populate additional variants for each option</key><key alias="deleteProduct">Delete Product</key><key alias="deleteVariant">Delete Variant</key><key alias="toggleOnSale">On Sale</key><key alias="toggleAvailable">Available</key><key alias="configVariant">Configure this variant</key><key alias="selectVariantOptions">Select the variant/options that you would like to create.</key><key alias="addFile">Add a file to your product variant</key><key alias="trackInventory">Track inventory for this variant</key><key alias="setInventoryPreferences">Set preferences for handling out of stock and adjust inventory for this variant</key><!-- phrases --><key alias="barcodeExamples">e.g. UPC, ISBN</key><key alias="optionNameExamples">(e.g. Size, Style, Color)</key><key alias="optionValueExamples">(e.g. red, green, blue)</key><key alias="hasDigitalDownload">This variant has digital goods</key><key alias="hasOptions">This variant has options (like size or color)</key><key alias="isTaxable">This variant is taxable</key><key alias="isShippable">This variant is shippable</key><key alias="isOnSale">This variant is on sale</key><key alias="isAvailable">This variant is available to purchase</key><key alias="noProduct">You have no products.</key><key alias="newProductPrompt">How about creating one now? Simply press the New Product button.</key><key alias="limitSelect">Number of products to display</key><key alias="mustUniqueSku">Must have a unique SKU</key><key alias="inventoryWarning"><![CDATA[<p>Important: If you choose to track inventory, it must be set manually for each variant (listed below) once this product has been saved.  However, you can set a base default inventory, applied to <strong>all variants</strong> here.</p>]]></key><key alias="startingInventoryWarning"><![CDATA[(Will set starting inventory for <strong>all variants</strong> and <strong>all warehouses</strong>)]]></key><key alias="productOnSale">On sale</key></area>
+    <key alias="barcode">Barcode</key>
+    <key alias="manufacturer">Manufacturer</key>
+    <key alias="manufacturerModel">Manufacturer's Model No.</key>
+    <key alias="variantInfo">Variant Information</key>
+    <key alias="variantOptions">Variant Options</key>
+    <key alias="downloads">Digital Downloads</key>
+    <key alias="optionName">Option Name</key>
+    <key alias="optionValues">Option Values</key>
+    <!-- actions -->
+    <key alias="newProduct">New Product</key>
+    <key alias="createProduct">Create a Product</key>
+    <key alias="createProductSub">The Name field (above), Price, and SKU are required.  Everything else is optional.</key>
+    <key alias="newVariant">New Variant</key>
+    <key alias="newVariantFor">New Variant for</key>
+    <key alias="newVariantOn">This will be a new variant on the</key>
+    <key alias="addVariant">Add a Variant</key>
+    <key alias="addVariantSub">This will be a new variant on the %0% product.</key>
+    <key alias="addOption">Add Another Option</key>
+    <key alias="addOptions">Add options to this variant and auto-populate additional variants for each option</key>
+    <key alias="deleteProduct">Delete Product</key>
+    <key alias="deleteVariant">Delete Variant</key>
+    <key alias="toggleOnSale">On Sale</key>
+    <key alias="toggleAvailable">Available</key>
+    <key alias="configVariant">Configure this variant</key>
+    <key alias="selectVariantOptions">Select the variant/options that you would like to create.</key>
+    <key alias="addFile">Add a file to your product variant</key>
+    <key alias="trackInventory">Track inventory for this variant</key>
+    <key alias="setInventoryPreferences">Set preferences for handling out of stock and adjust inventory for this variant</key>
+    <!-- phrases -->
+    <key alias="barcodeExamples">e.g. UPC, ISBN</key>
+    <key alias="optionNameExamples">(e.g. Size, Style, Color)</key>
+    <key alias="optionValueExamples">(e.g. red, green, blue)</key>
+    <key alias="hasDigitalDownload">This variant has digital goods</key>
+    <key alias="hasOptions">This variant has options (like size or color)</key>
+    <key alias="isTaxable">This variant is taxable</key>
+    <key alias="isShippable">This variant is shippable</key>
+    <key alias="isOnSale">This variant is on sale</key>
+    <key alias="isAvailable">This variant is available to purchase</key>
+    <key alias="noProduct">You have no products.</key>
+    <key alias="newProductPrompt">How about creating one now? Simply press the New Product button.</key>
+    <key alias="limitSelect">Number of products to display</key>
+    <key alias="mustUniqueSku">Must have a unique SKU</key>
+    <key alias="inventoryWarning"><![CDATA[<p>Important: If you choose to track inventory, it must be set manually for each variant (listed below) once this product has been saved.  However, you can set a base default inventory, applied to <strong>all variants</strong> here.</p>]]></key>
+    <key alias="startingInventoryWarning"><![CDATA[(Will set starting inventory for <strong>all variants</strong> and <strong>all warehouses</strong>)]]></key>
+    <key alias="productOnSale">On sale</key>
+  </area>
   <area alias="merchelloOrder">
     <!-- things -->
     <key alias="invoice">Invoice</key>
@@ -27,7 +71,7 @@
     <key alias="orderNumber">Order #</key>
     <key alias="paymentStatus">Payment Status</key>
     <key alias="fulfillmentStatus">Fulfillment Status</key>
-    <key alias="lineItems"> Line Items</key>
+    <key alias="lineItems">Line Items</key>
     <key alias="orderName">[Order Name]</key>
     <key alias="sales">Sales</key>
     <key alias="saleInformation">Sale Information</key>
@@ -49,6 +93,10 @@
     <key alias="refundPayment">Refund Payment</key>
     <key alias="voidPaymentConfirmMessage">Are you sure you would like to void this payment?</key>
     <key alias="refundMethod">Refund method</key>
+    <key alias="archiveSales">Archive Sales</key>
+    <key alias="unarchiveSales">Unarchive Sales</key>
+    <key alias="noSalesYet">You have no sales yet</key>
+    <key alias="butSoonYouWill">but soon you will!</key>
   </area>
   <area alias="merchelloOrderView">
     <!-- things -->

--- a/src/Merchello.Web.UI.Client/src/views/gatewayproviders/paymentproviders.html
+++ b/src/Merchello.Web.UI.Client/src/views/gatewayproviders/paymentproviders.html
@@ -26,7 +26,7 @@
                         {{provider.name}}
                         <small data-ng-bind="provider.description"></small>
                         <div data-ng-show="provider.gatewayResources.length > 0">
-                            <a data-ng-click="provider.showSelectResource = !provider.showSelectResource"><i class="icon-bill-dollar"></i><localize key="merchelloPayment_addPaymentMethod" /> </a>
+                            <a data-ng-click="provider.showSelectResource = !provider.showSelectResource"><i class="icon-bill-dollar"></i> <localize key="merchelloPayment_addPaymentMethod" /></a>
                             <div class="well" data-ng-class="{ 'open': provider.showSelectResource, 'closed': (!provider.showSelectResource) }">
                                 <label><localize key="merchelloPayment_resourceType" /> </label>
                                 <select class="form-control col-xs-12 span12" data-ng-model="provider.selectedGatewayResource" data-ng-options="r.name for r in provider.gatewayResources track by r.serviceCode"></select>

--- a/src/Merchello.Web.UI/App_Plugins/Merchello/Backoffice/Merchello/saleslist.html
+++ b/src/Merchello.Web.UI/App_Plugins/Merchello/Backoffice/Merchello/saleslist.html
@@ -81,8 +81,8 @@
                                 <div class="btn-group">
                                     <a href="#" class="btn dropdown-toggle" data-toggle="dropdown">Bulk Action ({{selectedSalesCount}} sales selected) <i class="icon-navigation-down"></i></a>
                                     <ul class="dropdown-menu">
-                                        <li><a href="#">Archive Sales</a></li>
-                                        <li><a href="#">Unarchive Sales</a></li>
+                                        <li><a href="#"><localize key="merchelloOrder_archiveSales">Archive Sales</localize></a></li>
+                                        <li><a href="#"><localize key="merchelloOrder_unarchiveSales">Unarchive Sales</localize></a></li>
                                     </ul>
                                 </div>
                             </th>
@@ -107,8 +107,8 @@
 
                 <!-- Prompt to create products if no products in the catalog -->
                 <div class="pager well" data-ng-show="salesLoaded && invoices.length == 0">
-                    <h5>You Have No Sales Yet</h5>
-                    <p>But you will soon!</p>
+                    <h5><localize key="merchelloOrder_noSalesYet" /></h5>
+                    <p><localize key="merchelloOrder_butSoonYouWill" /></p>
                 </div>
 
             </div>

--- a/src/Merchello.Web/Trees/MerchelloTreeController.cs
+++ b/src/Merchello.Web/Trees/MerchelloTreeController.cs
@@ -38,11 +38,8 @@
         protected override TreeNodeCollection GetTreeNodes(string id, FormDataCollection queryStrings)
         {
             var collection = new TreeNodeCollection();
-
             var backoffice = MerchelloConfiguration.Current.BackOffice;
-
             var rootTrees = backoffice.GetTrees().Where(x => x.Visible).ToArray();
-
             var currentTree = rootTrees.FirstOrDefault(x => x.Id == id && x.Visible);
 
             collection.AddRange(
@@ -135,7 +132,6 @@
         {
             var types = ReportApiControllerResolver.Current.ResolvedTypes.ToArray();
             if (!types.Any()) return new TreeNode[] { };
-
 
             var atts = types.Select(x => x.GetCustomAttribute<BackOfficeTreeAttribute>(true)).OrderBy(x => x.SortOrder);
 


### PR DESCRIPTION
Updated some translations in da.xml
http://issues.merchello.com/youtrack/issue/M-732

Some of the text has not been translated yet, but most of it. Some words in English can't directly be translated to Danish, so I have to think of alternative words that makes sense in the context :)

Futhermore some text is still hardcoded and needs to be dynamic/possible to translate. E.g.the tree nodes seems to get their content from the xml in merchello.config, where we need to localize the titles:

```xml
<backoffice>
    <tree id="catalog" title="Products" icon="icon-barcode" routePath="merchello/merchello/productlist/manage" visible="true" sortOrder="1" />
    <tree id="orders" title="Sales" icon="icon-receipt-dollar" routePath="merchello/merchello/saleslist/manage" visible="true" sortOrder="2" />
    <tree id="customers" title="Customers" icon="icon-user-glasses" routePath="merchello/merchello/customerlist/manage" visible="true" sortOrder="3" />
    <tree id="marketing" title="Marketing" icon="icon-light-up" routePath="merchello/merchello/offerslist/manage" visible="true" sortOrder="4" />
    <tree id="reports" title="Reports" icon="icon-file-cabinet" routePath="merchello/merchello/reportslist/manage" visible="false" sortOrder="5" />
    <tree id="gateways" title="Gateway Providers" icon="icon-settings" routePath="merchello/merchello/gatewayproviderlist/manage" visible="true" sortOrder="6" />
</backoffice>
```

in Analytics we have done it like this we ui.text() https://github.com/warrenbuckley/Analytics/blob/7291fce1776688de56c6b6497cad55dcf47145e3/Analytics/Controllers/AnalyticsTreeController.cs#L35-L46 ... has been deprecated and instead their is now ILocalizedTextService in ApplicationContext.Services.

Here is an example of how to use it: https://twitter.com/Shazwazza/status/613986522631667712

The titles on tab and headings also needs to be localized. I have done some of the work in this PR, but still some translations is missing.

Furthermore I think we should avoid starting/ending spaces on the translations, but just add it in the markup/code where needed, so the translations only have spaces between words.