### PR TITLE
Implement EnumTypeFieldConverter.Product.Custom(alias)

### DIFF
--- a/src/Merchello.Core/Models/TypeFields/EnumTypeFieldConverter.cs
+++ b/src/Merchello.Core/Models/TypeFields/EnumTypeFieldConverter.cs
@@ -48,6 +48,15 @@
         }
 
         /// <summary>
+        /// Gets the <see cref="IAppliedPaymentTypeField"/>
+        /// </summary>
+        /// <returns></returns>
+        public static IProductTypeField Product
+        {
+            get { return new ProductTypeField(); }
+        }
+
+        /// <summary>
         /// Gets the <see cref="IEntityTypeField"/>
         /// </summary>
         internal static IEntityTypeField EntityType

--- a/src/Merchello.Core/Models/TypeFields/Interfaces/IProductTypeField.cs
+++ b/src/Merchello.Core/Models/TypeFields/Interfaces/IProductTypeField.cs
@@ -3,7 +3,7 @@
     /// <summary>
     /// Defines the ProductTypeField
     /// </summary>
-    internal interface IProductTypeField : ITypeFieldMapper<ProductType>
+    public interface IProductTypeField : ITypeFieldMapper<ProductType>
     {
          
     }

--- a/src/Merchello.Core/TypeFieldMapperEnumerations.cs
+++ b/src/Merchello.Core/TypeFieldMapperEnumerations.cs
@@ -107,7 +107,7 @@
     /// The product type.
     /// </summary>
     [SuppressMessage("StyleCop.CSharp.DocumentationRules", "SA1602:EnumerationItemsMustBeDocumented", Justification = "Reviewed. Suppression is OK here.")]
-    internal enum ProductType
+    public enum ProductType
     {
         Custom
     }


### PR DESCRIPTION
INCOMPLETE - the basic resolution of custom product typefields works but I didnt get as far as ensuring existing SKUs in the basket get updated.  Currently it still throws an error (item with this key has already been added)