### PR TITLE
Don't display the checkout pages if no products

### DIFF
--- a/src/Merchello.Bazaar/Controllers/BazaarCheckoutConfirmController.cs
+++ b/src/Merchello.Bazaar/Controllers/BazaarCheckoutConfirmController.cs
@@ -34,6 +34,13 @@
         /// </returns>
         public override ActionResult Index(RenderModel model)
         {
+            // Don't display the checkout form if there are no products (either due to timeout or manual URL entered)
+            if (!Basket.Items.Any())
+            {
+                var basketModel = ViewModelFactory.CreateBasket(model, Basket);
+                return View(basketModel.ThemeViewPath("Basket"), basketModel);
+            }
+
             // get the basket sale preparation
             var preparation = Basket.SalePreparation();
             preparation.RaiseCustomerEvents = false;

--- a/src/Merchello.Bazaar/Controllers/BazaarCheckoutController.cs
+++ b/src/Merchello.Bazaar/Controllers/BazaarCheckoutController.cs
@@ -1,6 +1,7 @@
 ﻿namespace Merchello.Bazaar.Controllers
 {
     using System.Web.Mvc;
+    using System.Linq;
 
     using Merchello.Bazaar.Attributes;
 
@@ -25,6 +26,13 @@
         /// </returns>
         public override ActionResult Index(RenderModel model)
         {
+            // Don't display the checkout form if there are no products (either due to timeout or manual URL entered)
+            if (!Basket.Items.Any())
+            {
+                var basketModel = ViewModelFactory.CreateBasket(model, Basket);
+                return View(basketModel.ThemeViewPath("Basket"), basketModel);
+            }
+
             var viewModel = ViewModelFactory.CreateCheckout(model, Basket, AllCountries, AllowedShipCountries);
 
             return this.View(viewModel.ThemeViewPath("Checkout"), viewModel);


### PR DESCRIPTION
Don't display the checkout form if there are no products (either due to timeout or manual URL entered)