### PR TITLE
Tryparse with InvariantCulture for all decimal's

### DIFF
--- a/src/Merchello.Core/Models/ExtendedDataExtensions.cs
+++ b/src/Merchello.Core/Models/ExtendedDataExtensions.cs
@@ -504,8 +504,7 @@
         /// </returns>
         public static decimal GetPriceValue(this ExtendedDataCollection extendedData)
         {
-            decimal converted = decimal.TryParse(extendedData.GetValue(Constants.ExtendedDataKeys.Price), System.Globalization.NumberStyles.AllowDecimalPoint, CultureInfo.InvariantCulture, out converted) ? converted : 0;
-            return converted;
+            return extendedData.GetValue(Constants.ExtendedDataKeys.Price).AsDecimal();
         }
 
         /// <summary>
@@ -986,7 +985,7 @@
         private static decimal AsDecimal(this string value)
         {
             decimal converted;
-            return decimal.TryParse(value, out converted) ? converted : 0;
+            return decimal.TryParse(value, System.Globalization.NumberStyles.AllowDecimalPoint, CultureInfo.InvariantCulture, out converted) ? converted : 0;
         }
 
         /// <summary>


### PR DESCRIPTION
Currenctly GetSalePriceValue and GetWeightValue (and probably height,
width, ... as well) are giving wrong values (3000000kg instead of 3kg
for example) in cultures such as nl_BE and fr_BE.
This should fix it.