### PR TITLE
Fixed rate shipping on sale bug

### DIFF
--- a/src/Merchello.Core/Gateways/Shipping/FixedRate/FixedRateShipmentLineItemVisitor.cs
+++ b/src/Merchello.Core/Gateways/Shipping/FixedRate/FixedRateShipmentLineItemVisitor.cs
@@ -25,8 +25,8 @@ namespace Merchello.Core.Gateways.Shipping.FixedRate
             if(UseOnSalePriceIfOnSale)
             {
                 TotalPrice += lineItem.ExtendedData.GetOnSaleValue()
-                    ? lineItem.ExtendedData.GetSalePriceValue()
-                    : lineItem.ExtendedData.GetPriceValue();
+                    ? lineItem.ExtendedData.GetSalePriceValue() * lineItem.Quantity
+                    : lineItem.ExtendedData.GetPriceValue() * lineItem.Quantity;
             }
             else
             {


### PR DESCRIPTION
When shipping cost is based on the on sale price the price is not multiplied by the quantity causing the value of the cart to be much lower than it should be and user gets under charged for the shipping.