### PR TITLE
Fixes M-322

### DIFF
--- a/src/Merchello.Bazaar/Controllers/Api/BazaarSiteApiController.cs
+++ b/src/Merchello.Bazaar/Controllers/Api/BazaarSiteApiController.cs
@@ -192,7 +192,7 @@
 
                 var optionChoices = new List<ProductAttributeDisplay>();
 
-                foreach (var choice in option.Choices)
+                foreach (var choice in option.Choices.OrderBy(x => x.SortOrder))
                 {
                     if (ValidateOptionChoice(variants, choice.Key))
                     {

--- a/src/Merchello.Web.UI.Client/src/views/directives/tagmanager.directive.js
+++ b/src/Merchello.Web.UI.Client/src/views/directives/tagmanager.directive.js
@@ -12,7 +12,7 @@
             scope: { option: '=' },
             template:
             '<div class="tags">' +
-            '<a ng-repeat="(idx, choice) in option.choices" class="tag" ng-click="remove(idx)">{{choice.name}}</a>' +
+            '<a ng-repeat="(idx, choice) in option.choices | orderBy:\'sortOrder\'" class="tag" ng-click="remove(idx)">{{choice.name}}</a>' +
             '</div>' +
             '<input type="text" placeholder="Add a choice..." ng-model="newChoiceName" /> ' +
             '<merchello-add-icon do-add="add()"></merchello-add-icon>',

--- a/src/Merchello.Web.UI.Client/src/views/products/directives/product.reorderoptions.directive.js
+++ b/src/Merchello.Web.UI.Client/src/views/products/directives/product.reorderoptions.directive.js
@@ -25,12 +25,11 @@
 
                 // Settings for the sortable directive
                 $scope.sortableOptions = {
-                    stop: function (e, ui) {
+                    update: function (e, ui) {
+                        // Updating sortOrder of each productOption.
                         for (var i = 0; i < $scope.product.productOptions.length; i++) {
-                            $scope.product.productOptions[i].sortOrder(i + 1);
+                            $scope.product.productOptions[i].sortOrder = i + 1;
                         }
-                        console.log('lets fix');
-                        $scope.product.fixAttributeSortOrders();
                     },
                     axis: 'y',
                     cursor: "move"

--- a/src/Merchello.Web.UI.Client/src/views/products/directives/product.reorderoptions.directive.js
+++ b/src/Merchello.Web.UI.Client/src/views/products/directives/product.reorderoptions.directive.js
@@ -29,6 +29,7 @@
                         for (var i = 0; i < $scope.product.productOptions.length; i++) {
                             $scope.product.productOptions[i].sortOrder(i + 1);
                         }
+                        console.log('lets fix');
                         $scope.product.fixAttributeSortOrders();
                     },
                     axis: 'y',

--- a/src/Merchello.Web.UI.Client/src/views/products/directives/product.reorderoptions.tpl.html
+++ b/src/Merchello.Web.UI.Client/src/views/products/directives/product.reorderoptions.tpl.html
@@ -4,12 +4,13 @@
     <p><localize key="merchelloProductEdit_dragAndReorderHelper" /></p>
 
     <ul class="reorder" ui-sortable="sortableOptions" ng-model="product.productOptions">
-        <li data-ng-repeat="option in product.productOptions">
+        
+        <li data-ng-repeat="option in product.productOptions | orderBy:'sortOrder'">
             <span class="col-xs-3 span3">
                 <a class="btn btn-link variant"><i class="icon-thumbnail-list"></i> {{option.name}}</a>
             </span>
             <span class="options col-xs-9 span9" ui-sortable="sortableChoices" ng-model="option.choices">
-                <a class="btn btn-link option" data-ng-repeat="attribute in option.choices"><i class="icon-thumbnail-list"></i> {{attribute.name}}</a>
+                <a class="btn btn-link option" data-ng-repeat="attribute in option.choices | orderBy:'sortOrder'"><i class="icon-thumbnail-list"></i> {{attribute.name}}</a>
             </span>
         </li>
     </ul>


### PR DESCRIPTION
This fixes this issue: 
http://issues.merchello.com/youtrack/issue/M-322#

Also talked about here: https://our.umbraco.org/projects/collaboration/merchello/merchello/72019-re-ordering-variants-in-merchello-back-end

Now the backoffice is using the sortOrder-property to sort the lists correctly.