### PR TITLE
M-1087 - Fixed. [Fast Track] Enabling Unobtrusive Validation YSODs Forms (register and checkout address)

### DIFF
--- a/src/Merchello.FastTrack.Ui/App_Plugins/FastTrack/Views/BraintreeStandardCc/PaymentForm.cshtml
+++ b/src/Merchello.FastTrack.Ui/App_Plugins/FastTrack/Views/BraintreeStandardCc/PaymentForm.cshtml
@@ -2,6 +2,8 @@
 @using System.Web.Mvc.Html
 @using Merchello.FastTrack.Ui
 @using Merchello.Web.Models.Ui
+
+<h3>Braintree credit card</h3>
 <form data-muiscript="braintree">
     <div class="row">
         <div class="col-md-12">

--- a/src/Merchello.FastTrack.Ui/App_Plugins/FastTrack/Views/CheckoutPaymentMethod/ResolvePayment.cshtml
+++ b/src/Merchello.FastTrack.Ui/App_Plugins/FastTrack/Views/CheckoutPaymentMethod/ResolvePayment.cshtml
@@ -8,7 +8,6 @@
             @Html.Action("PaymentForm", "CashPayment", new { area = "FastTrack" })
             break;
         case "BrainTree.StandardTransaction":
-            <h3>Braintree credit card</h3>
             @Html.Action("PaymentForm", "BraintreeStandardCc", new { area = "FastTrack" })
             break;
         case "BrainTree.PayPal.OneTime":

--- a/src/Merchello.FastTrack/Models/FastTrackBillingAddressModel.cs
+++ b/src/Merchello.FastTrack/Models/FastTrackBillingAddressModel.cs
@@ -35,7 +35,7 @@
         /// </summary>
         [Display(ResourceType = typeof(StoreFormsResource), Name = "LabelEmailAddress")]
         [Required(ErrorMessageResourceType = typeof(StoreFormsResource), ErrorMessageResourceName = "RequiredEmailAddress")]
-        [EmailAddress(ErrorMessageResourceType = typeof(StoreFormsResource), ErrorMessageResourceName = "InvalidEmailAddress")]
+        [EmailAddress(ErrorMessageResourceType = typeof(StoreFormsResource), ErrorMessageResourceName = "InvalidEmailAddress", ErrorMessage = null)]
         public override string Email { get; set; }
 
         /// <summary>

--- a/src/Merchello.FastTrack/Models/Membership/NewMemberModel.cs
+++ b/src/Merchello.FastTrack/Models/Membership/NewMemberModel.cs
@@ -15,7 +15,7 @@
         /// </summary>
         [Required(ErrorMessageResourceType = typeof(StoreFormsResource), ErrorMessageResourceName = "RequiredEmailAddress")]
         [Display(ResourceType = typeof(StoreFormsResource), Name = "LabelEmailAddress")]
-        [EmailAddress(ErrorMessageResourceType = typeof(StoreFormsResource), ErrorMessageResourceName = "InvalidEmailAddress")]
+        [EmailAddress(ErrorMessageResourceType = typeof(StoreFormsResource), ErrorMessageResourceName = "InvalidEmailAddress", ErrorMessage = null)]
         public string Email { get; set; }
 
         /// <summary>


### PR DESCRIPTION
It's a known issue in .Net 4.5. Adding "ErrorMessage = null" named parameter solve this.