### PR TITLE
Merchello Basket View should not have reference to Merchello.FastTrack.Ui

### DIFF
--- a/src/Merchello.FastTrack.Ui/Views/ftBasket.cshtml
+++ b/src/Merchello.FastTrack.Ui/Views/ftBasket.cshtml
@@ -10,6 +10,15 @@
 @if (CurrentCustomer.Basket().Items.Any())
 {
     @Html.Action("BasketForm", "StoreBasket", new { area = "Merchello" })
+
+    <div class="row">
+        <div class="col-lg-8">
+            <a href="@ExampleUiHelper.Content.GetStoreRoot().Url">Continue Shopping</a>
+        </div>
+        <div class="col-lg-4 text-right">
+            <a href="@ExampleUiHelper.Content.GetCheckout().Url" class="btn btn-primary">Checkout</a>
+        </div>
+    </div>
 }
 else
 {

--- a/src/Merchello.Web.UI.Client/src/config/partials/StoreBasket/BasketForm.cshtml
+++ b/src/Merchello.Web.UI.Client/src/config/partials/StoreBasket/BasketForm.cshtml
@@ -95,13 +95,5 @@
     </tbody>
     </table>
 
-        <div class="row">
-            <div class="col-lg-8">
-                <a href="@ExampleUiHelper.Content.GetStoreRoot().Url">Continue Shopping</a>
-            </div>
-            <div class="col-lg-4 text-right">
-                <a href="@ExampleUiHelper.Content.GetCheckout().Url" class="btn btn-primary">Checkout</a>
-            </div>
-        </div>
     }
 }

--- a/src/Merchello.Web.UI.Client/src/config/partials/StoreBasket/BasketForm.cshtml
+++ b/src/Merchello.Web.UI.Client/src/config/partials/StoreBasket/BasketForm.cshtml
@@ -1,7 +1,6 @@
 ﻿@inherits Umbraco.Web.Mvc.UmbracoViewPage<Merchello.Web.Store.Models.StoreBasketModel>
 @using System.Web.Mvc.Html
 @using Merchello.Core
-@using Merchello.FastTrack.Ui
 @using Merchello.Web.Models.Ui
 @using Merchello.Web.Store.Controllers
 @using Umbraco.Core.Models


### PR DESCRIPTION
The Merchello Ui stuff had a reference to the FastTrack which is incorrect. Meaning you would have to install FastTrack to use this call

@Html.Action("BasketForm", "StoreBasket", new { area = "Merchello" })

So I have removed the reference and moved the Checkout buttons into the FastTrack view

