### PR TITLE
Fixing incorrect regex in dateHelper

### DIFF
--- a/src/Merchello.FastTrack.Ui/App_Plugins/Merchello/js/merchello.services.js
+++ b/src/Merchello.FastTrack.Ui/App_Plugins/Merchello/js/merchello.services.js
@@ -13,7 +13,7 @@ angular.module('merchello.services').service('dateHelper', [
         this.convertToJsDate = function(dateString, dateFormat) {
             // date formats in merchello start with MM, dd, or yyyy
             if(dateString.indexOf('/') === -1) {
-                dateString = dateString.replace(/-|./g, '/');
+                dateString = dateString.replace(/-|\./g, '/');
             }
             var splitDate = dateString.split('/');
             var date;

--- a/src/Merchello.Web.UI.Client/src/common/services/dateHelper.service.js
+++ b/src/Merchello.Web.UI.Client/src/common/services/dateHelper.service.js
@@ -5,7 +5,7 @@ angular.module('merchello.services').service('dateHelper', [
         this.convertToJsDate = function(dateString, dateFormat) {
             // date formats in merchello start with MM, dd, or yyyy
             if(dateString.indexOf('/') === -1) {
-                dateString = dateString.replace(/-|./g, '/');
+                dateString = dateString.replace(/-|\./g, '/');
             }
             var splitDate = dateString.split('/');
             var date;


### PR DESCRIPTION
The previous regex overwrote the entire date string with /, added an escape for . (dot).