### PR TITLE
Change DetachedContentValues on ProductAttribute DTO to be [ntext]

### DIFF
--- a/src/Merchello.Core/Models/Rdbms/ProductAttributeDto.cs
+++ b/src/Merchello.Core/Models/Rdbms/ProductAttributeDto.cs
@@ -45,6 +45,7 @@
         /// </summary>
         [Column("detachedContentValues")]
         [NullSetting(NullSetting = NullSettings.Null)]
+        [SpecialDbType(SpecialDbTypes.NTEXT)]
         public string DetachedContentValues { get; set; }
 
         /// <summary>


### PR DESCRIPTION
Makes fresh install db schema consistent with upgrade schema.

Prior to this fix, a fresh install creates `[merchProductAttribute].[detachedContentValues]` with data type `[nvarchar](255)`. Thus, when any significant information (which causes the serialized JSON to be >255 chars in length) is persisted to the Extended Content for a Shared Product Option, the following exception occurs and is logged:
```
Umbraco.Core.Persistence.UmbracoDatabase - Database exception occurred
System.Data.SqlClient.SqlException (0x80131904): String or binary data would be truncated.
The statement has been terminated.

```
This fix uses the `SpecialDbType` attribute to specify that the type should instead be `[ntext]`.