### PR TITLE
Save inventory, detached, in batches of 100.

### DIFF
--- a/src/Merchello.Core/Persistence/Repositories/ProductVariantRepository.cs
+++ b/src/Merchello.Core/Persistence/Repositories/ProductVariantRepository.cs
@@ -388,6 +388,7 @@
             var parms = new List<object>();
             var inserts = new List<CatalogInventoryDto>();
 
+            var variantIndex = 0;
             foreach (var productVariant in productVariants)
             {
                 foreach (var dto in inventoryDtos.Where(i => i.ProductVariantKey == productVariant.Key))
@@ -443,6 +444,16 @@
                             UpdateDate = inv.UpdateDate
                         });
                     }
+                }
+                
+                //split into batches of 100
+                if (++variantIndex >= 100) {
+                    if (!string.IsNullOrEmpty(sqlStatement))
+                    {
+                    		Database.Execute(sqlStatement, parms.ToArray());
+                    }
+                		variantIndex = 0;
+                    sqlStatement = string.Empty;
                 }
             }
 
@@ -553,6 +564,7 @@
             var paramIndex = 0;
             var inserts = new List<ProductVariantDetachedContentDto>();
 
+            var variantIndex = 0;
             foreach (var variant in variants)
             {
                 if (variant.DetachedContents.Any() || existing.Any(x => x.ProductVariantKey == variant.Key))
@@ -598,6 +610,16 @@
                             parms.Add(dto.ProductVariantKey);
                         }
                     }
+                }
+                
+                //split into batches of 100
+                if (++variantIndex >= 100) {
+                    if (!string.IsNullOrEmpty(sqlStatement))
+                    {
+                    		Database.Execute(sqlStatement, parms.ToArray());
+                    }
+                		variantIndex = 0;
+                    sqlStatement = string.Empty;
                 }
             }
 


### PR DESCRIPTION
When a Product has lots of Product Options, very many Product Variants will be generated. Merchello may fail to save changes to the Product Variants because it must submit more SQL parameters with the `UPDATE` query than SQL Server allows.

For example, Consider a Product with 3 Options, **A**, **B** and **C**.
**A** has **16** alternatives.
**B** has **11** alternatives.
**C** has **2** alternatives.
The total number of Product Variants will be: 16 * 11 * 2 = **352**.

`ProductVariantRepository` methods `SaveCatalogInventory` and `SaveDetachedContents` use string concatenation to prepare a large multi-statement SQL `UPDATE` script.
In the case of `SaveCatalogInventory`, there are **6** SQL params per `UPDATE` statement: 6 * 352 = **2,112**
In the case of `SaveDetachedContents`, there are **8** params per `UPDATE`: 8 * 352 = **2,816**

Prior to this proposed fix, SQL Server would throw the following exception:
```
ERROR Umbraco.Core.Persistence.UmbracoDatabase - Database exception occurred
System.Data.SqlClient.SqlException (0x80131904): The incoming request has too many parameters. The server supports a maximum of 2100 parameters. Reduce the number of parameters and resend the request.
   at System.Data.SqlClient.SqlConnection.OnError(SqlException exception, Boolean breakConnection, Action`1 wrapCloseInAction)
```

This proposed fix increments `variantIndex` until 100 `UPDATE` statements have been prepared, then executes `sqlStatement` and resets it to `String.Empty`, continuing with the next 100 statements or part thereof.

This proposed fix has worked great for our purposes, but please carefully consider whether it is appropriate to make it a permanent part of Merchello. It somewhat decreases the transactional integrity of the `UPDATE` operation, because, for example, if the 3rd batch of 100 fails to save, the initial 200 will still have been persisted to the database. Mitigating this risk is the fact that the user is still informed of the error while saving, and can be expected to further examine their data in response.

It may also be desirable to increase the threshold of **100**. It has a theoretical max of _350_ for `SaveCatalogInventory`, or _262_ for `SaveDetachedContents`.

Any further questions, please ask.