### PR TITLE
Fix Customer Basket recovery fail for deleted Product

### DIFF
--- a/src/Merchello.Web/Models/ContentEditing/Content/DetachedContentDisplayExtensions.cs
+++ b/src/Merchello.Web/Models/ContentEditing/Content/DetachedContentDisplayExtensions.cs
@@ -203,6 +203,8 @@ namespace Merchello.Web.Models.ContentEditing.Content
         /// </param>
         internal static void EnsureValueConversion(this ProductDisplayBase display, DetachedValuesConversionType conversionType = DetachedValuesConversionType.Db)
         {
+            if (display == null) return;
+
             if (display.DetachedContents.Any())
             {
                 foreach (var dc in display.DetachedContents)

--- a/src/Merchello.Web/Pluggable/CustomerContextBase.cs
+++ b/src/Merchello.Web/Pluggable/CustomerContextBase.cs
@@ -19,6 +19,8 @@ namespace Merchello.Web.Pluggable
     using Umbraco.Core.Logging;
     using Umbraco.Web;
 
+    using Newtonsoft.Json;
+
     /// <summary>
     /// A base class for defining customer contexts for various membership providers.
     /// </summary>
@@ -496,16 +498,19 @@ namespace Merchello.Web.Pluggable
 
             if (cookie != null)
             {
+                var parsedOk = false;
                 try
                 {
                     this.ContextData = cookie.ToCustomerContextData();
-                    this.TryGetCustomer(this.ContextData.Key);
+                    parsedOk = true;
                 }
-                catch (Exception ex)
+                catch (JsonException ex)
                 {
                     MultiLogHelper.Error<CustomerContext>("Decrypted guid did not parse", ex);
                     this.CreateAnonymousCustomer();
                 }
+
+                if (parsedOk) this.TryGetCustomer(this.ContextData.Key);
             }
             else
             {


### PR DESCRIPTION
Crux of the issue:

- `EnsureValueConversion` in `DetachedContentDisplayExtensions` was throwing an exception if the display parameter was null.

- `Initialize` in `CustomerContextBase` was performing non-specific `Exception` handling when first parsing the Customer cookie.

An exception (and YSOD) would only result if `CustomerContextBase.Initialize` was called twice. But the Customer's Basket would be lost in either circumstance.


Steps to Reproduce:

I have a View, `AccountPage.cshtml`:
```
@inherits Merchello.Web.Mvc.MerchelloTemplatePage
@{
	Layout = "Page.cshtml";
	var cust = CurrentCustomer;
	var basket = cust.Basket();
}
```
_etc._ This view shows the contents of any current basket that the customer has. Our `Checkout` pages do the same (and also break in the same way as described below); `Account`'s just simpler.

`AccountPage`'s parent view, `Page.cshtml`, has another parent view, `Master.cshtml`, which calls `Html.Partial("Navigation")` to implement the Navigation of the site. Here's `Navigation.cshtml`:
```
@inherits Merchello.Web.Mvc.MerchelloTemplatePage
@{
	var cust = CurrentCustomer;
	var basket = cust.Basket();
}
```
_etc._

If:
- I have previously logged in as `testperson@blahwherever`, and added an item to my cart, AND
- That product is no longer available in the Store (deleted), AND
- I return to the store and log in as `testperson@blahwherever`
Then this exception occurs for BOTH calls to `.CurrentCustomer` - i.e. in `AccountPage.cshtml` AND for `Navigation.cshtml`.
![20161112 - exception](https://cloud.githubusercontent.com/assets/21004338/20237124/6c60b4dc-a92e-11e6-87c7-511bfc47801b.PNG)


For `AccountPage.cshtml` the exception is non-fatal and logged (see log excerpt at bottom). But when it occurs for `Navigation.cshtml` (or any other subsequent attempt to retrieve `CurrentCustomer`), it is fatal and a YSOD is returned.
![20161112 - ysod](https://cloud.githubusercontent.com/assets/21004338/20237126/951d0eac-a92e-11e6-98c4-3b588a35af59.PNG)

This discrepancy is due to the slightly different Call Stacks - the call to `TryGetCustomer` in `Initialize()` at line 502 of `CustomerContextBase.cs` is wrapped in a catch-all `try-catch` block, whereas the call to `TryGetCustomer` in `Initialize()` at line 490 of `CustomerContextBase.cs` is not.
![20161112 - account page call stack](https://cloud.githubusercontent.com/assets/21004338/20237132/c5ac073a-a92e-11e6-9484-b5dbc986b075.png)
![20161112 - navigation call stack](https://cloud.githubusercontent.com/assets/21004338/20237135/c7a060c2-a92e-11e6-895b-2bd0c5e51937.png)


If I remove `Html.Partial("Navigation")` from the `Master` page, the Account page loads fine, but obviously without Navigation.

Trapping and handling the exception in Account page was impossible as the exception is swallowed.
This prevented me from doing something like catching the `NullReferenceException`, doing something back-doory to clear the corrupted basket, and redirecting to the current URL.

So I have patched both concerns. The new behaviors are:

- return early from `DetachedContentDisplayExtensions.EnsureValueConversion` if the "display" parameter is null. This may have side-effects if there is any instance where calls to this method were relying on an exception being thrown instead of a null return value.
- only catch `JsonException`s when calling `HttpCookie.ToCustomerContextData()` in the `try-catch` block in `CustomerContextBase.Initialize`, and move the call to `TryGetCustomer(Guid)` out of the `try` so that any downstream `JsonException` is propagated successfully.


```
 2016-11-12 18:16:34,993 [P8936/D2/T15] ERROR Merchello.Web.CustomerContext - Decrypted guid did not parse
System.NullReferenceException: Object reference not set to an instance of an object.
   at Merchello.Web.Models.ContentEditing.Content.DetachedContentDisplayExtensions.EnsureValueConversion(ProductDisplayBase display, DetachedValuesConversionType conversionType)
   at Merchello.Web.Search.CachedProductQuery.GetProductVariantByKey(Guid key)
   at Merchello.Web.Validation.ProductSkuExistsValidationVisitor.Visit(ILineItem lineItem)
   at Merchello.Core.Models.LineItemCollection.Accept(ILineItemVisitor visitor)
   at Merchello.Web.Validation.Tasks.ValidateProductsExistTask.PerformTask(ValidationResult`1 value)
   at Merchello.Core.Chains.AttemptChainTaskHandler`1.Execute(T arg)
   at Merchello.Web.Workflow.CustomerItemCache.CustomerItemCacheBase.Validate()
   at Merchello.Web.Workflow.Basket.GetBasket(IMerchelloContext merchelloContext, ICustomerBase customer)
   at Merchello.Web.Pluggable.CustomerContextBase.ConvertBasket(ICustomerBase customer, String membershipId, String customerLoginName)
   at Merchello.Web.CustomerContext.EnsureCustomerCreationAndConvertBasket(ICustomerBase customer)
   at Merchello.Web.Pluggable.CustomerContextBase.TryGetCustomer(Guid key)
   at Merchello.Web.Pluggable.CustomerContextBase.Initialize()
```