### PR TITLE
Fixed encoding and layout of message editor

### DIFF
--- a/src/Merchello.Web.UI.Client/src/scss/modules/_vieweditor.scss
+++ b/src/Merchello.Web.UI.Client/src/scss/modules/_vieweditor.scss
@@ -2,3 +2,7 @@
   border: 1px solid #ccc;
   width: 100%;
 }
+
+.merchello-codemirror .CodeMirror {
+    height:750px; /* setting the height of the edit view */
+}

--- a/src/Merchello.Web.UI.Client/src/views/gatewayproviders/notificationmessageeditor.html
+++ b/src/Merchello.Web.UI.Client/src/views/gatewayproviders/notificationmessageeditor.html
@@ -83,7 +83,7 @@
                         <small><localize key="merchelloNotificationsEdit_emailTemplateHelper" /></small>
                     </label>
                     <div class="merchello-controls">
-                        <div class="row-fluid col-xs-8 span8">
+                        <div class="row-fluid col-xs-11 span11">
                             <ng-form data-ng-if="!notificationMessage.bodyTextIsFilePath">
                                 <label for="template"><localize key="merchelloNotificationsEdit_emailTemplateEditBody" /></label>
                                 <textarea name="messageTemplate" id="messageTemplate" data-ng-model="notificationMessage.bodyText" class="col-xs-12 span12" rows="10"></textarea>

--- a/src/Merchello.Web/Pluggable/PluginViewProviderBase{T}.cs
+++ b/src/Merchello.Web/Pluggable/PluginViewProviderBase{T}.cs
@@ -1,3 +1,5 @@
+using System.Text;
+
 namespace Merchello.Web.Pluggable
 {
     using System.Collections.Generic;
@@ -89,7 +91,7 @@ namespace Merchello.Web.Pluggable
             var fullFileName = string.Format("{0}{1}", mapped, fileName);
             if (File.Exists(fullFileName))
             {
-                File.WriteAllText(fullFileName, viewBody);
+                File.WriteAllText(fullFileName, viewBody,Encoding.UTF8);
 
                 return true;
             }


### PR DESCRIPTION
I was working with a message views that contained special chars like the swedish å,ä and ö and after saving them in the backoffice these chars was messed up. Explicitly setting the encoding did the trick. 

This PR also contains some minor changes to the layout, I've increased the width and height of the codemirror-editor.