### PR TITLE
Bug fixed creation of a DigitalMedia entity

### DIFF
--- a/src/Merchello.Core/Persistence/Factories/DigitalMediaFactory.cs
+++ b/src/Merchello.Core/Persistence/Factories/DigitalMediaFactory.cs
@@ -57,7 +57,7 @@
                               ProductVariantKey = entity.ProductVariantKey,
                               CreateDate = entity.CreateDate,
                               UpdateDate = entity.UpdateDate,
-                              ExtendedData = entity.ExtendedData.SerializeToXml()
+                              ExtendedData = entity.ExtendedData?.SerializeToXml()
                           };
 
             return dto;

--- a/src/Merchello.Core/Persistence/Factories/DigitalMediaFactory.cs
+++ b/src/Merchello.Core/Persistence/Factories/DigitalMediaFactory.cs
@@ -57,7 +57,7 @@
                               ProductVariantKey = entity.ProductVariantKey,
                               CreateDate = entity.CreateDate,
                               UpdateDate = entity.UpdateDate,
-                              ExtendedData = entity.ExtendedData?.SerializeToXml()
+                              ExtendedData = entity.ExtendedData.SerializeToXml()
                           };
 
             return dto;


### PR DESCRIPTION
When creating a new DigitalMedia entity the ExtendedData would always be null, but the code expected it to have a value.