### PR TITLE
M-1305 Cannot perform search using ProductContentQuery() due to error…

### DIFF
--- a/src/Merchello.Core/Persistence/Repositories/ProductRepository.cs
+++ b/src/Merchello.Core/Persistence/Repositories/ProductRepository.cs
@@ -1126,7 +1126,7 @@
                 .Append("FROM [merchProduct2EntityCollection]")
                 .Append(
                     "WHERE [merchProduct2EntityCollection].[entityCollectionKey] IN (@eckeys)",
-                    new { @eckey = collectionKeys })
+                    new { @eckeys = collectionKeys })
                 .Append("GROUP BY productKey")
                 .Append("HAVING COUNT(*) = @keyCount", new { @keyCount = collectionKeys.Count() })
                 .Append(")");


### PR DESCRIPTION
M-1305 Cannot perform search using ProductContentQuery() due to error in "@eckeys"
Hi, I'm using Merchello v2.5 and I'm trying to add a search feature using ProductContentQuery() and AddConstraint(searchTerm). However, when executing the query, the following exception is thrown:

System.ArgumentException: 'Parameter '@eckeys' specified but none of the passed arguments have a property with this name (in 'WHERE [merchProduct2EntityCollection].[entityCollectionKey] IN (@eckeys)')'