### PR TITLE
AVS Data, Extended Data JS Bug Fix & Assigned By Fix

### DIFF
--- a/src/Merchello.Core/Constants.ExtendedDataKeys.cs
+++ b/src/Merchello.Core/Constants.ExtendedDataKeys.cs
@@ -193,6 +193,17 @@
                 get { return "merchPaymentMethod"; }
             }
 
+            /// <summary>
+            /// Gets the AvsCvvData extended data key
+            /// </summary>
+            public static string AvsCvvData
+            {
+                get
+                {
+                    return "merchAvsCvvData";
+                }
+            }
+
             //// ProductVariant -----------------------------------------------------------------
 
             /// <summary>

--- a/src/Merchello.FastTrack.Ui/Web.config
+++ b/src/Merchello.FastTrack.Ui/Web.config
@@ -64,7 +64,7 @@
   <connectionStrings>
     <remove name="umbracoDbDSN" />
     <!--<add name="umbracoDbDSN" connectionString="Data Source=|DataDirectory|\Umbraco.sdf;Flush Interval=1;" providerName="System.Data.SqlServerCe.4.0" />-->
-    <add name="umbracoDbDSN" connectionString="Server=omen;Database=fasttrack;User ID=merchello;Password=merchello;" providerName="System.Data.SqlClient" />
+    <add name="umbracoDbDSN" connectionString="Server=.\MSSQLSERVER2016;database=Merchello;Trusted_Connection=true" providerName="System.Data.SqlClient" />
     <!-- Important: If you're upgrading Umbraco, do not clear the connection string / provider name during your web.config merge. -->
   </connectionStrings>
   <system.data>

--- a/src/Merchello.Providers/Payment/Braintree/MappingExtensions.cs
+++ b/src/Merchello.Providers/Payment/Braintree/MappingExtensions.cs
@@ -1,7 +1,7 @@
 ﻿namespace Merchello.Providers.Payment.Braintree
 {
     using System.Diagnostics.CodeAnalysis;
-
+    using System.Text;
     using AutoMapper;
 
     using global::Braintree;
@@ -179,6 +179,27 @@
         public static void SetBraintreeTransaction(this ExtendedDataCollection extendedData, Transaction transaction)
         {
             extendedData.SetValue(Constants.Braintree.ExtendedDataKeys.BraintreeTransaction, JsonConvert.SerializeObject(transaction));
+        }
+
+        /// <summary>
+        /// Adds the AVS and CVV data to the payment so it can be displayed in the back office
+        /// </summary>
+        /// <param name="extendedData"></param>
+        /// <param name="transaction"></param>
+        public static void SetAvsCvvData(this ExtendedDataCollection extendedData, Transaction transaction)
+        {
+            // Pull out all the AVS and CVV Data as we need to display this
+            var sb = new StringBuilder();
+            if (!string.IsNullOrEmpty(transaction.AvsErrorResponseCode))
+            {
+                sb.Append($"AvsErrorResponseCode: {transaction.AvsErrorResponseCode} | ");
+            }
+            sb.Append($"AvsPostalCodeResponseCode: {transaction.AvsPostalCodeResponseCode} | ");
+            sb.Append($"AvsStreetAddressResponseCode: {transaction.AvsStreetAddressResponseCode} | ");
+            sb.Append($"CvvResponseCode: {transaction.CvvResponseCode}");
+
+            // Set it into the Extended data
+            extendedData.SetValue(Core.Constants.ExtendedDataKeys.AvsCvvData, sb.ToString());
         }
 
         /// <summary>

--- a/src/Merchello.Providers/Payment/Braintree/MappingExtensions.cs
+++ b/src/Merchello.Providers/Payment/Braintree/MappingExtensions.cs
@@ -192,11 +192,11 @@
             var sb = new StringBuilder();
             if (!string.IsNullOrEmpty(transaction.AvsErrorResponseCode))
             {
-                sb.Append($"AvsErrorResponseCode: {transaction.AvsErrorResponseCode} | ");
+                sb.AppendFormat("AvsErrorResponseCode: {0} | ", transaction.AvsErrorResponseCode);
             }
-            sb.Append($"AvsPostalCodeResponseCode: {transaction.AvsPostalCodeResponseCode} | ");
-            sb.Append($"AvsStreetAddressResponseCode: {transaction.AvsStreetAddressResponseCode} | ");
-            sb.Append($"CvvResponseCode: {transaction.CvvResponseCode}");
+            sb.AppendFormat("AvsPostalCodeResponseCode: {0} | ", transaction.AvsPostalCodeResponseCode);
+            sb.AppendFormat("AvsStreetAddressResponseCode: {0} | ", transaction.AvsStreetAddressResponseCode);
+            sb.AppendFormat("CvvResponseCode: {0}" , transaction.CvvResponseCode);
 
             // Set it into the Extended data
             extendedData.SetValue(Core.Constants.ExtendedDataKeys.AvsCvvData, sb.ToString());

--- a/src/Merchello.Providers/Payment/Braintree/Provider/BraintreeStandardPaymentGatewayBase.cs
+++ b/src/Merchello.Providers/Payment/Braintree/Provider/BraintreeStandardPaymentGatewayBase.cs
@@ -1,7 +1,6 @@
 ﻿namespace Merchello.Providers.Payment.Braintree.Provider
 {
     using System;
-
     using Merchello.Core;
     using Merchello.Core.Gateways.Payment;
     using Merchello.Core.Models;
@@ -168,6 +167,9 @@
             if (result.IsSuccess())
             {
                 payment.ExtendedData.SetBraintreeTransaction(result.Target);
+
+                // AVS and CVV data
+                payment.ExtendedData.SetAvsCvvData(result.Target);
 
                 if (option == TransactionOption.Authorize) payment.Authorized = true;
                 if (option == TransactionOption.SubmitForSettlement)

--- a/src/Merchello.Providers/Payment/Braintree/Provider/BraintreeStandardTransactionPaymentGatewayMethod.cs
+++ b/src/Merchello.Providers/Payment/Braintree/Provider/BraintreeStandardTransactionPaymentGatewayMethod.cs
@@ -192,6 +192,9 @@
             {
                 payment.ExtendedData.SetBraintreeTransaction(result.Target);
 
+                // AVS and CVV data
+                payment.ExtendedData.SetAvsCvvData(result.Target);
+
                 if (option == TransactionOption.Authorize) payment.Authorized = true;
                 if (option == TransactionOption.SubmitForSettlement)
                 {

--- a/src/Merchello.Providers/Payment/Braintree/Provider/BraintreeVaultPaymentGatewayMethodBase.cs
+++ b/src/Merchello.Providers/Payment/Braintree/Provider/BraintreeVaultPaymentGatewayMethodBase.cs
@@ -181,6 +181,9 @@
             {
                 payment.ExtendedData.SetBraintreeTransaction(result.Target);
 
+                // AVS and CVV data
+                payment.ExtendedData.SetAvsCvvData(result.Target);
+
                 if (option == TransactionOption.Authorize) payment.Authorized = true;
                 if (option == TransactionOption.SubmitForSettlement)
                 {

--- a/src/Merchello.Web.UI.Client/src/common/models/ExtendedDataDisplay.model.js
+++ b/src/Merchello.Web.UI.Client/src/common/models/ExtendedDataDisplay.model.js
@@ -14,7 +14,10 @@
     ExtendedDataDisplay.prototype = (function() {
 
         function isEmpty() {
-            return this.items.length === 0;
+            if (this.items) {
+                return this.items.length === 0;
+            }
+            return true;
         }
 
         function getValue(key) {
@@ -37,6 +40,11 @@
         }
 
         function setValue(key, value) {
+
+            // See if items is null and if so, make it an array
+            if (!this.items) {
+                this.items = [];
+            }
 
             var existing = _.find(this.items, function(item) {
               return item.key === key;

--- a/src/Merchello.Web.UI.Client/src/views/sales/directives/invoiceitemizationtable.tpl.html
+++ b/src/Merchello.Web.UI.Client/src/views/sales/directives/invoiceitemizationtable.tpl.html
@@ -44,8 +44,9 @@
     <tr data-ng-show="itemization.adjustments.length > 0" data-ng-repeat="adjustmentItem in itemization.adjustments">
         <td colspan="4" class="adjustment-name">
             {{adjustmentItem.name}}
-            <span data-ng-show="adjustmentItem.userName !== ''"><localize key="merchelloSales_adjustmentAssignedBy"></localize>: {{ adjustmentItem.userName}}</span>
-            <span data-ng-show="adjustmentItem.email !== ''">(<a href="mailto:{{ adjustmentItem.email }}"><small>{{adjustmentItem.email}}</small></a>)</span>
+            <span data-ng-show="adjustmentItem.extendedData.items[0].value !== ''">
+                <localize key="merchelloSales_adjustmentAssignedBy"></localize>: {{ adjustmentItem.extendedData.items[0].value}} (<small>{{adjustmentItem.extendedData.items[1].value}}</small>)
+            </span>             
         </td>
         <td class="text-right">
             <span data-ng-show="adjustmentItem.price < 0">({{adjustmentItem.absPrice() | currency : currencySymbol}})</span>

--- a/src/Merchello.Web.UI.Client/src/views/sales/directives/manageinvoiceadjustments.directive.js
+++ b/src/Merchello.Web.UI.Client/src/views/sales/directives/manageinvoiceadjustments.directive.js
@@ -56,7 +56,7 @@ angular.module('merchello.directives').directive('manageInvoiceAdjustments',
                 function manageAdjustmentsDialogConfirm(adjustments) {
                     if (adjustments.items !== undefined) {
 
-                    var user = userService.getCurrentUser().then(function(user) {
+                    userService.getCurrentUser().then(function(user) {
 
                         _.each(adjustments.items, function(item) {
                             if (item.key === '') {

--- a/src/Merchello.Web.UI.Client/src/views/sales/invoicepayments.controller.js
+++ b/src/Merchello.Web.UI.Client/src/views/sales/invoicepayments.controller.js
@@ -30,6 +30,30 @@ angular.module('merchello').controller('Merchello.Backoffice.InvoicePaymentsCont
             $scope.showVoid = showVoid;
             $scope.showRefund = showRefund;
 
+            // Helper to check for AvsCvvData
+            $scope.hasAvsCvvData = function(items) {
+                var hasAvsCvv = false;
+                if (items) {
+                    for (var i = 0; i < items.length; i++) {
+                        if (items[i].key === "merchAvsCvvData") {
+                            hasAvsCvv = true;
+                            break;
+                        }
+                    }
+                }
+                return hasAvsCvv;
+            };
+
+            // Helper to show the data
+            $scope.showAvsCvvData = function(items) {
+                for (var i = 0; i < items.length; i++) {
+                    if (items[i].key === "merchAvsCvvData") {
+                        return items[i].value;
+                    }
+                }
+                return "-";
+            };
+
             function init() {
                 var key = $routeParams.id;
                 loadInvoice(key);
@@ -168,8 +192,8 @@ angular.module('merchello').controller('Merchello.Backoffice.InvoicePaymentsCont
 
                     if (key === 'removed') {
                         var empty = paymentMethodDisplayBuilder.createDefault();
-                            $scope.paymentMethods.push(empty)
-                        }   
+                        $scope.paymentMethods.push(empty);
+                    }   
                         var promise = paymentGatewayProviderResource.getPaymentMethodByKey(key);
                         promise.then(function(method) {
                             $scope.paymentMethods.push(method);

--- a/src/Merchello.Web.UI.Client/src/views/sales/invoicepayments.html
+++ b/src/Merchello.Web.UI.Client/src/views/sales/invoicepayments.html
@@ -20,9 +20,7 @@
                     <!--<div class="merchello-section-label">
                         <localize key="merchelloPayment_paymentInfo" />
                         <small>Payment methods &amp; dates</small>
-                    </div>-->
-       
-
+                    </div>-->      
                         <div class="row-fluid">
 
                             <div data-ng-repeat="payment in payments" data-ng-show="preValuesLoaded">
@@ -30,11 +28,16 @@
                                 <h4>
                                     <localize key="merchelloPayment_paymentMethod" />: {{payment.paymentMethodName}}
                                 </h4>
+                                
+                                <div ng-show="hasAvsCvvData(payment.extendedData.items)">
+                                    <h5>AVS/CVV</h5>
+                                    {{ showAvsCvvData(payment.extendedData.items) }}
+                                </div>                               
 
                                 <div class="btn-toolbar pull-right umb-btn-toolbar">
                                     <button class="btn btn-default text-right" data-ng-click="openVoidPaymentDialog(payment)" data-ng-show="showVoid(payment)"><localize key="merchelloButtons_void" /></button>
                                     <button class="btn btn-default text-right" data-ng-show="showRefund(payment)" data-ng-click="openRefundPaymentDialog(payment)"><localize key="merchelloButtons_refund" /></button>
-                                </div>
+                                </div>                               
 
                                 <h5>History</h5>
 


### PR DESCRIPTION
- Adds the ability to show AVS (& CVV) data on the payment in the back office 
- Fixed bug that stops all extended data being added, which was introduced after previous serialisation fix
- Fixes assigned by blank entry when making adjustments on the invoice

