### PR TITLE
Enable sorting for the date fields against a product

### DIFF
--- a/src/Merchello.Examine/Providers/ProductIndexer.cs
+++ b/src/Merchello.Examine/Providers/ProductIndexer.cs
@@ -126,8 +126,8 @@
                 new StaticField("versionKey", FieldIndexTypes.NOT_ANALYZED, false, string.Empty),
                 new StaticField("staticCollectionKeys", FieldIndexTypes.ANALYZED, false, string.Empty),
                 new StaticField("slugs", FieldIndexTypes.NOT_ANALYZED, false, string.Empty),
-                new StaticField("createDate", FieldIndexTypes.NOT_ANALYZED, false, "DATETIME"),
-                new StaticField("updateDate", FieldIndexTypes.NOT_ANALYZED, false, "DATETIME"),
+                new StaticField("createDate", FieldIndexTypes.NOT_ANALYZED, true, "DATETIME"),
+                new StaticField("updateDate", FieldIndexTypes.NOT_ANALYZED, true, "DATETIME"),
                 new StaticField("allDocs", FieldIndexTypes.ANALYZED, false, string.Empty)
             };
 


### PR DESCRIPTION
This is so that we can sort against this field when using an Examine search provider