### PR TITLE
Braintree Needs MerchantAccountId In Some Cases

### DIFF
--- a/src/Merchello.Core/Persistence/Repositories/GatewayProviderRepository.cs
+++ b/src/Merchello.Core/Persistence/Repositories/GatewayProviderRepository.cs
@@ -223,6 +223,7 @@
             entity.ResetDirtyProperties();
 
             RuntimeCache.ClearCacheItem(Cache.CacheKeys.GetEntityCacheKey<IGatewayProviderSettings>(entity.Key));
+            RuntimeCache.ClearCacheItem(Cache.CacheKeys.GetEntityCacheKey<GatewayProviderSettings>(entity.Key));
         }
     }
 }

--- a/src/Merchello.Providers/Payment/Braintree/Provider/BraintreePaymentGatewayMethodBase.cs
+++ b/src/Merchello.Providers/Payment/Braintree/Provider/BraintreePaymentGatewayMethodBase.cs
@@ -180,13 +180,14 @@
         /// The payment method nonce.
         /// </param>
         /// <param name="email">The email</param>
+        /// <param name="merchantAccountId"></param>
         /// <returns>
         /// The <see cref="IPaymentResult"/>.
         /// </returns>
         /// <remarks>
         /// This converts the <see cref="Result{Transaction}"/> into Merchello's <see cref="IPaymentResult"/>
         /// </remarks>
-        protected abstract IPaymentResult ProcessPayment(IInvoice invoice, TransactionOption option, decimal amount, string token, string email = "");
+        protected abstract IPaymentResult ProcessPayment(IInvoice invoice, TransactionOption option, decimal amount, string token, string email = "", string merchantAccountId = "");
 
 
         /// <summary>

--- a/src/Merchello.Providers/Payment/Braintree/Provider/BraintreeStandardPaymentGatewayBase.cs
+++ b/src/Merchello.Providers/Payment/Braintree/Provider/BraintreeStandardPaymentGatewayBase.cs
@@ -51,10 +51,10 @@
         protected override IPaymentResult PerformAuthorizePayment(IInvoice invoice, ProcessorArgumentCollection args)
         {
             var authorizeAmount = invoice.Total;
-            if (args.ContainsKey("authorizePaymentAmount"))
-            {
-                authorizeAmount = Convert.ToDecimal(args["authorizePaymentAmount"]);
-            }
+            if (args.ContainsKey("authorizePaymentAmount")) authorizeAmount = Convert.ToDecimal(args["authorizePaymentAmount"]);
+
+            var merchantAccountId = string.Empty;
+            if (args.ContainsKey("merchantAccountId")) merchantAccountId = args["merchantAccountId"];
 
             var paymentMethodNonce = args.GetPaymentMethodNonce();
 
@@ -65,7 +65,7 @@
                 return new PaymentResult(Attempt<IPayment>.Fail(error), invoice, false);
             }
 
-            var attempt = this.ProcessPayment(invoice, TransactionOption.Authorize, authorizeAmount, paymentMethodNonce);
+            var attempt = this.ProcessPayment(invoice, TransactionOption.Authorize, authorizeAmount, paymentMethodNonce, "", merchantAccountId);
 
             var payment = attempt.Payment.Result;
 
@@ -103,7 +103,7 @@
         /// </remarks>
         protected override IPaymentResult PerformAuthorizeCapturePayment(IInvoice invoice, decimal amount, ProcessorArgumentCollection args)
         {
-            var paymentMethodNonce = args.GetPaymentMethodNonce();
+            var paymentMethodNonce = args.GetPaymentMethodNonce();           
 
             if (string.IsNullOrEmpty(paymentMethodNonce))
             {
@@ -116,7 +116,10 @@
             var email = string.Empty;
             if (args.ContainsKey("customerEmail")) email = args["customerEmail"];
 
-            var attempt = this.ProcessPayment(invoice, TransactionOption.SubmitForSettlement, amount, paymentMethodNonce, email);
+            var merchantAccountId = string.Empty;
+            if (args.ContainsKey("merchantAccountId")) merchantAccountId = args["merchantAccountId"];
+
+            var attempt = this.ProcessPayment(invoice, TransactionOption.SubmitForSettlement, amount, paymentMethodNonce, email, merchantAccountId);
 
             var payment = attempt.Payment.Result;
 
@@ -152,13 +155,14 @@
         /// <param name="email">
         /// The email.
         /// </param>
+        /// <param name="merchantAccountId"></param>
         /// <returns>
         /// The <see cref="IPaymentResult"/>.
         /// </returns>
         /// <remarks>
         /// This converts the <see cref="Result{T}"/> into Merchello <see cref="IPaymentResult"/>
         /// </remarks>
-        protected override IPaymentResult ProcessPayment(IInvoice invoice, TransactionOption option, decimal amount, string token, string email = "")
+        protected override IPaymentResult ProcessPayment(IInvoice invoice, TransactionOption option, decimal amount, string token, string email = "", string merchantAccountId = "")
         {
             var payment = this.GatewayProviderService.CreatePayment(PaymentMethodType.CreditCard, amount, this.PaymentMethod.Key);
 
@@ -168,7 +172,7 @@
             payment.PaymentMethodName = "Braintree PayPal One Time Transaction";
             payment.ExtendedData.SetValue(Constants.Braintree.ProcessorArguments.PaymentMethodNonce, token);
 
-            var result = this.BraintreeApiService.Transaction.Sale(invoice, amount, token, option: option, email: email);
+            var result = this.BraintreeApiService.Transaction.Sale(invoice, amount, token, option: option, email: email, merchantAccountId: merchantAccountId);
 
             if (result.IsSuccess())
             {

--- a/src/Merchello.Providers/Payment/Braintree/Provider/BraintreeStandardTransactionPaymentGatewayMethod.cs
+++ b/src/Merchello.Providers/Payment/Braintree/Provider/BraintreeStandardTransactionPaymentGatewayMethod.cs
@@ -75,10 +75,10 @@
         protected override IPaymentResult PerformAuthorizePayment(IInvoice invoice, ProcessorArgumentCollection args)
         {
             var authorizeAmount = invoice.Total;
-            if (args.ContainsKey("authorizePaymentAmount"))
-            {
-                authorizeAmount = Convert.ToDecimal(args["authorizePaymentAmount"]);
-            }
+            if (args.ContainsKey("authorizePaymentAmount")) authorizeAmount = Convert.ToDecimal(args["authorizePaymentAmount"]);
+
+            var merchantAccountId = string.Empty;
+            if (args.ContainsKey("merchantAccountId")) merchantAccountId = args["merchantAccountId"];
 
             var paymentMethodNonce = args.GetPaymentMethodNonce();
 
@@ -89,7 +89,7 @@
                 return new PaymentResult(Attempt<IPayment>.Fail(error), invoice, false);
             }
             
-            var attempt = this.ProcessPayment(invoice, TransactionOption.Authorize, authorizeAmount, paymentMethodNonce);
+            var attempt = this.ProcessPayment(invoice, TransactionOption.Authorize, authorizeAmount, paymentMethodNonce, "", merchantAccountId);
 
             var payment = attempt.Payment.Result;
 
@@ -140,7 +140,10 @@
             var email = string.Empty;
             if (args.ContainsKey("customerEmail")) email = args["customerEmail"];
 
-            var attempt = this.ProcessPayment(invoice, TransactionOption.SubmitForSettlement, amount, paymentMethodNonce, email);
+            var merchantAccountId = string.Empty;
+            if (args.ContainsKey("merchantAccountId")) merchantAccountId = args["merchantAccountId"];
+
+            var attempt = this.ProcessPayment(invoice, TransactionOption.SubmitForSettlement, amount, paymentMethodNonce, email, merchantAccountId);
 
             var payment = attempt.Payment.Result;
 
@@ -176,13 +179,14 @@
         /// <param name="email">
         /// The email.
         /// </param>
+        /// <param name="merchantAccountId"></param>
         /// <returns>
         /// The <see cref="IPaymentResult"/>.
         /// </returns>
         /// <remarks>
         /// This converts the <see cref="Result{T}"/> into Merchello <see cref="IPaymentResult"/>
         /// </remarks>
-        protected override IPaymentResult ProcessPayment(IInvoice invoice, TransactionOption option, decimal amount, string token, string email = "")
+        protected override IPaymentResult ProcessPayment(IInvoice invoice, TransactionOption option, decimal amount, string token, string email = "", string merchantAccountId = "")
         {
             var payment = this.GatewayProviderService.CreatePayment(PaymentMethodType.CreditCard, amount, this.PaymentMethod.Key);
 
@@ -192,7 +196,7 @@
             payment.PaymentMethodName = this.BackOfficePaymentMethodName;
             payment.ExtendedData.SetValue(Constants.Braintree.ProcessorArguments.PaymentMethodNonce, token);
 
-            var result = this.BraintreeApiService.Transaction.Sale(invoice, amount, token, option: option, email: email);
+            var result = this.BraintreeApiService.Transaction.Sale(invoice, amount, token, option: option, email: email, merchantAccountId: merchantAccountId);
 
             if (result.IsSuccess())
             {

--- a/src/Merchello.Providers/Payment/Braintree/Services/BraintreeApiRequestFactory.cs
+++ b/src/Merchello.Providers/Payment/Braintree/Services/BraintreeApiRequestFactory.cs
@@ -303,7 +303,7 @@
                                   PaymentMethodNonce = paymentMethodNonce
                               };
             if (isDefault)
-            request.Options = new PaymentMethodOptionsRequest()
+            request.Options = new PaymentMethodOptionsRequest
                                   {
                                       MakeDefault = true
                                   };
@@ -331,7 +331,7 @@
 
             return new PaymentMethodRequest
                     {
-                        BillingAddress = addressRequest                    
+                        BillingAddress = addressRequest
                     };
         }
 
@@ -376,19 +376,25 @@
         /// <param name="price">
         /// An optional price used to override the plan price.
         /// </param>
+        /// <param name="merchantAccountId"></param>
         /// <returns>
         /// The <see cref="SubscriptionRequest"/>.
         /// </returns>
-        public SubscriptionRequest CreateSubscriptionRequest(string paymentMethodToken, string planId, decimal? price = null)
+        public SubscriptionRequest CreateSubscriptionRequest(string paymentMethodToken, string planId, decimal? price = null, string merchantAccountId = "")
         {
             Mandate.ParameterNotNullOrEmpty(paymentMethodToken, "paymentMethodToken");
             Mandate.ParameterNotNullOrEmpty(planId, "planId");
 
-            var request = new SubscriptionRequest()
+            var request = new SubscriptionRequest
                        {
                            PaymentMethodToken = paymentMethodToken, 
-                           PlanId = planId,
+                           PlanId = planId
                        };
+
+            if (!string.IsNullOrEmpty(merchantAccountId))
+            {
+                request.MerchantAccountId = merchantAccountId;
+            }
 
             // TODO figure out the descriptor for nicer Credit Card statements
             // TODO https://www.braintreepayments.com/docs/dotnet/transactions/dynamic_descriptors
@@ -420,14 +426,15 @@
         /// <param name="addTrialPeriod">
         /// Adds a trial period to a plan that normally does not have one.
         /// </param>
+        /// <param name="merchantAccountId"></param>
         /// <returns>
         /// The <see cref="SubscriptionRequest"/>.
         /// </returns>
-        public SubscriptionRequest CreateSubscriptionRequest(string paymentMethodToken, string planId, int trialDuration, SubscriptionDurationUnit trialDurationUnit, bool addTrialPeriod = false)
+        public SubscriptionRequest CreateSubscriptionRequest(string paymentMethodToken, string planId, int trialDuration, SubscriptionDurationUnit trialDurationUnit, bool addTrialPeriod = false, string merchantAccountId = "")
         {
             if (trialDurationUnit == null) trialDurationUnit = SubscriptionDurationUnit.MONTH;
 
-            var request = this.CreateSubscriptionRequest(paymentMethodToken, planId);
+            var request = this.CreateSubscriptionRequest(paymentMethodToken, planId, null, merchantAccountId);
 
             if (request.TrialDuration > 0) request.TrialDuration = trialDuration;
 
@@ -509,10 +516,13 @@
         /// <param name="transactionOption">
         /// The transaction Option.
         /// </param>
+        /// <param name="merchantAccountId">
+        /// Optional Merchant Id
+        /// </param>
         /// <returns>
         /// The <see cref="TransactionRequest"/>.
         /// </returns>
-        public TransactionRequest CreateTransactionRequest(IInvoice invoice, decimal amount, string paymentMethodNonce, ICustomer customer = null, TransactionOption transactionOption = TransactionOption.Authorize)
+        public TransactionRequest CreateTransactionRequest(IInvoice invoice, decimal amount, string paymentMethodNonce, ICustomer customer = null, TransactionOption transactionOption = TransactionOption.Authorize, string merchantAccountId = "")
         {
             var request = new TransactionRequest
                        {
@@ -520,8 +530,14 @@
                            OrderId = invoice.PrefixedInvoiceNumber(),
                            PaymentMethodNonce = paymentMethodNonce,
                            BillingAddress = this.CreateAddressRequest(invoice.GetBillingAddress()),
-                           Channel = Constants.Braintree.TransactionChannel,                         
+                           Channel = Constants.Braintree.TransactionChannel
                        };
+
+            // Optional merchantAccountId
+            if (!string.IsNullOrEmpty(merchantAccountId))
+            {
+                request.MerchantAccountId = merchantAccountId;
+            }
 
             if (customer != null) request.Customer = this.CreateCustomerRequest(customer);
             
@@ -548,10 +564,11 @@
         /// <param name="transactionOption">
         /// The transaction option.
         /// </param>
+        /// <param name="merchantAccountId"></param>
         /// <returns>
         /// The <see cref="TransactionRequest"/>.
         /// </returns>
-        public TransactionRequest CreateVaultTransactionRequest(IInvoice invoice, decimal amount, string paymentMethodToken, TransactionOption transactionOption = TransactionOption.SubmitForSettlement)
+        public TransactionRequest CreateVaultTransactionRequest(IInvoice invoice, decimal amount, string paymentMethodToken, TransactionOption transactionOption = TransactionOption.SubmitForSettlement, string merchantAccountId = "")
         {
             var request = new TransactionRequest
             {
@@ -561,6 +578,12 @@
                 BillingAddress = this.CreateAddressRequest(invoice.GetBillingAddress()),
                 Channel = Constants.Braintree.TransactionChannel
             };
+
+            // Optional merchantAccountId
+            if (!string.IsNullOrEmpty(merchantAccountId))
+            {
+                request.MerchantAccountId = merchantAccountId;
+            }
 
             if (transactionOption == TransactionOption.SubmitForSettlement)
             {

--- a/src/Merchello.Providers/Payment/Braintree/Services/BraintreeTransactionApiService.cs
+++ b/src/Merchello.Providers/Payment/Braintree/Services/BraintreeTransactionApiService.cs
@@ -35,9 +35,9 @@
         }
 
         /// <inheritdoc />
-        public Result<Transaction> Sale(IInvoice invoice, decimal amount, string paymentMethodNonce = "", ICustomer customer = null, TransactionOption option = TransactionOption.SubmitForSettlement, string email = "")
+        public Result<Transaction> Sale(IInvoice invoice, decimal amount, string paymentMethodNonce = "", ICustomer customer = null, TransactionOption option = TransactionOption.SubmitForSettlement, string email = "", string merchantAccountId = "")
         {
-            var request = this.RequestFactory.CreateTransactionRequest(invoice, amount, paymentMethodNonce, customer, option);
+            var request = this.RequestFactory.CreateTransactionRequest(invoice, amount, paymentMethodNonce, customer, option, merchantAccountId);
             if (customer == null && !string.IsNullOrEmpty(email))
             {
                 request.Customer = new CustomerRequest() { Email = email };
@@ -50,15 +50,15 @@
         }
 
         /// <inheritdoc />
-        public Result<Transaction> Sale(IInvoice invoice, decimal amount, string paymentMethodNonce, ICustomer customer, IAddress billingAddress, TransactionOption option = TransactionOption.SubmitForSettlement)
+        public Result<Transaction> Sale(IInvoice invoice, decimal amount, string paymentMethodNonce, ICustomer customer, IAddress billingAddress, TransactionOption option = TransactionOption.SubmitForSettlement, string merchantAccountId = "")
         {
-            return this.Sale(invoice, amount, paymentMethodNonce, customer, billingAddress, null, option);
+            return this.Sale(invoice, amount, paymentMethodNonce, customer, billingAddress, null, option, merchantAccountId);
         }
 
         /// <inheritdoc />
-        public Result<Transaction> Sale(IInvoice invoice, decimal amount, string paymentMethodNonce, ICustomer customer, IAddress billingAddress, IAddress shippingAddress, TransactionOption option = TransactionOption.SubmitForSettlement)
+        public Result<Transaction> Sale(IInvoice invoice, decimal amount, string paymentMethodNonce, ICustomer customer, IAddress billingAddress, IAddress shippingAddress, TransactionOption option = TransactionOption.SubmitForSettlement, string merchantAccountId = "")
         {
-            var request = this.RequestFactory.CreateTransactionRequest(invoice, amount, paymentMethodNonce, customer, option);
+            var request = this.RequestFactory.CreateTransactionRequest(invoice, amount, paymentMethodNonce, customer, option, merchantAccountId);
 
             if (billingAddress != null) request.BillingAddress = this.RequestFactory.CreateAddressRequest(billingAddress);
             if (shippingAddress != null) request.ShippingAddress = this.RequestFactory.CreateAddressRequest(shippingAddress);
@@ -73,9 +73,9 @@
         public Result<Transaction> VaultSale(
             IInvoice invoice, decimal amount,
             string paymentMethodToken,
-            TransactionOption option = TransactionOption.SubmitForSettlement)
+            TransactionOption option = TransactionOption.SubmitForSettlement, string merchantAccountId = "")
         {
-            var request = this.RequestFactory.CreateVaultTransactionRequest(invoice, amount, paymentMethodToken, option);
+            var request = this.RequestFactory.CreateVaultTransactionRequest(invoice, amount, paymentMethodToken, option, merchantAccountId);
 
             LogHelper.Info<BraintreeTransactionApiService>(string.Format("Braintree Vault Transaction attempt ({0}) for Invoice {1}", option.ToString(), invoice.PrefixedInvoiceNumber()));
             var attempt = this.TryGetApiResult(() => this.BraintreeGateway.Transaction.Sale(request));

--- a/src/Merchello.Providers/Payment/Braintree/Services/IBraintreeTransactionApiService.cs
+++ b/src/Merchello.Providers/Payment/Braintree/Services/IBraintreeTransactionApiService.cs
@@ -32,10 +32,12 @@
         /// <param name="option">
         /// The transaction option.
         /// </param>
+        /// <param name="email"></param>
+        /// <param name="merchantAccountId"></param>
         /// <returns>
         /// The <see cref="IPaymentResult"/>.
         /// </returns>
-        Result<Transaction> Sale(IInvoice invoice, decimal amount, string paymentMethodNonce, ICustomer customer = null, TransactionOption option = TransactionOption.SubmitForSettlement, string email = "");
+        Result<Transaction> Sale(IInvoice invoice, decimal amount, string paymentMethodNonce, ICustomer customer = null, TransactionOption option = TransactionOption.SubmitForSettlement, string email = "", string merchantAccountId = "");
 
         /// <summary>
         /// The sale.
@@ -58,10 +60,11 @@
         /// <param name="option">
         /// The transaction option.
         /// </param>
+        /// <param name="merchantAccountId"></param>
         /// <returns>
         /// The <see cref="IPaymentResult"/>.
         /// </returns>
-        Result<Transaction> Sale(IInvoice invoice, decimal amount, string paymentMethodNonce, ICustomer customer, IAddress billingAddress, TransactionOption option = TransactionOption.SubmitForSettlement);
+        Result<Transaction> Sale(IInvoice invoice, decimal amount, string paymentMethodNonce, ICustomer customer, IAddress billingAddress, TransactionOption option = TransactionOption.SubmitForSettlement, string merchantAccountId = "");
 
         /// <summary>
         /// Performs a Braintree sales transaction
@@ -87,10 +90,11 @@
         /// <param name="option">
         /// The transaction option.
         /// </param>
+        /// <param name="merchantAccountId"></param>
         /// <returns>
         /// The <see cref="IPaymentResult"/>.
         /// </returns>
-        Result<Transaction> Sale(IInvoice invoice, decimal amount, string paymentMethodNonce, ICustomer customer, IAddress billingAddress, IAddress shippingAddress, TransactionOption option = TransactionOption.SubmitForSettlement);
+        Result<Transaction> Sale(IInvoice invoice, decimal amount, string paymentMethodNonce, ICustomer customer, IAddress billingAddress, IAddress shippingAddress, TransactionOption option = TransactionOption.SubmitForSettlement, string merchantAccountId = "");
 
         /// <summary>
         /// Performs a Braintree Transaction using a vaulted credit card.
@@ -107,10 +111,11 @@
         /// <param name="option">
         /// The option.
         /// </param>
+        /// <param name="merchantAccountId"></param>
         /// <returns>
         /// The <see cref="Result{Transaction}"/>.
         /// </returns>
-        Result<Transaction> VaultSale(IInvoice invoice, decimal amount, string paymentMethodToken, TransactionOption option = TransactionOption.SubmitForSettlement);
+        Result<Transaction> VaultSale(IInvoice invoice, decimal amount, string paymentMethodToken, TransactionOption option = TransactionOption.SubmitForSettlement, string merchantAccountId = "");
 
         /// <summary>
         /// Performs a Braintree submit for settlement transaction


### PR DESCRIPTION
Some braintree users have a single braintree account but with many merchant account ids (Different websites using same account usually). Updated Braintree Payment Provider to allow optional MerchantAccountId which can be passed in via the ProcessorArgumentCollection 