### PR TITLE
Fix SalesOverTime report to include time in its queries

### DIFF
--- a/src/Merchello.Web/Editors/Reports/SalesOverTimeReportApiController.cs
+++ b/src/Merchello.Web/Editors/Reports/SalesOverTimeReportApiController.cs
@@ -218,10 +218,10 @@
 
             while (currentDate <= endDate)
             {
-                currentDate = startDate.AddMonths(1);
+                var monthEnd = currentDate.AddMonths(1).AddMilliseconds(-1);
                 count++;
-                results.Add(this.GetResults(startDate, currentDate));
-                startDate = currentDate;
+                results.Add(this.GetResults(currentDate, monthEnd));
+                currentDate = currentDate.AddMonths(1);
             }
 
             return new QueryResultDisplay()


### PR DESCRIPTION
This is in addition to #2086. Orders with no time are not getting picked up by the SalesOverTime report. Currently an order with a datetime of 2017-05-01T00:00:00 is being picked up for the April figures because the search is BETWEEN 2017-04-01 and 2017-05-01.