### PR TITLE
stop including all variants in the product listing api response, only…

### DIFF
--- a/src/Merchello.Web/Editors/ProductApiController.cs
+++ b/src/Merchello.Web/Editors/ProductApiController.cs
@@ -328,7 +328,7 @@
                 query.SortBy,
                 query.SortDirection);
 
-            return results.ToQueryResultDisplay<IProduct, ProductDisplay>(MapToProductDisplay);
+            return results.ToQueryResultDisplay<IProduct, ProductDisplay>(MapToProductListingDisplay);
         }
 
         /// <summary>
@@ -653,6 +653,23 @@
         private static ProductDisplay MapToProductDisplay(IProduct product)
         {
             return product.ToProductDisplay(DetachedValuesConversionType.Editor);
+        }
+
+        /// <summary>
+        /// Maps <see cref="IProduct"/> to <see cref="ProductDisplay"/>.
+        /// </summary>
+        /// <param name="product">
+        /// The product.
+        /// </param>
+        /// <returns>
+        /// The <see cref="ProductDisplay"/>.
+        /// </returns>
+        /// <remarks>
+        /// Delegated to mapping function
+        /// </remarks>
+        private static ProductDisplay MapToProductListingDisplay(IProduct product)
+        {
+            return product.ToProductListingDisplay(DetachedValuesConversionType.Editor);
         }
 
         /// <summary>

--- a/src/Merchello.Web/Models/ContentEditing/ProductDisplayExtensions.cs
+++ b/src/Merchello.Web/Models/ContentEditing/ProductDisplayExtensions.cs
@@ -228,6 +228,35 @@
             return productDisplay;
         }
 
+        /// <summary>
+        /// Maps a <see cref="IProduct"/> to <see cref="ProductDisplay"/>.
+        /// </summary>
+        /// <param name="product">
+        /// The product.
+        /// </param>
+        /// <param name="conversionType">
+        /// The detached value conversion type.
+        /// </param>
+        /// <returns>
+        /// The <see cref="ProductDisplay"/>.
+        /// </returns>
+        public static ProductDisplay ToProductListingDisplay(this IProduct product, DetachedValuesConversionType conversionType = DetachedValuesConversionType.Db)
+        {
+            var productDisplay = AutoMapper.Mapper.Map<ProductDisplay>(product);
+
+            if (productDisplay.ProductVariants.Count() > 1)
+            {
+                var lowPriceVar = productDisplay.ProductVariants.OrderBy(x => x.Price).ThenBy(x => x.Key).First();
+                var highPriceVar = productDisplay.ProductVariants.OrderBy(x => x.Price).ThenBy(x => x.Key).First();
+                var list = new List<ProductVariantDisplay> {lowPriceVar, highPriceVar};
+                productDisplay.ProductVariants = list;
+            }
+            
+            productDisplay.EnsureValueConversion(conversionType);
+            
+            return productDisplay;
+        }
+
 
         /// <summary>
         /// Turns a product variant into an InvoiceLineItem


### PR DESCRIPTION
Helps with #2042 

Not a perfect fix but the data is reduced to the min priced and max priced variant - when you have 10,000+ variants per product though we are seeing approx 30mb reduction per page!

With this number of variants the query is still slow however. I've looked at the SQL but can't see any obvious optimisations

Carl