### PR TITLE
Fix null reference error when the jsonResult is null and trying to access the detachedDataValues

### DIFF
--- a/src/Merchello.FastTrack.Ui/App_Plugins/Merchello/js/merchello.models.js
+++ b/src/Merchello.FastTrack.Ui/App_Plugins/Merchello/js/merchello.models.js
@@ -5732,7 +5732,9 @@ angular.module('merchello.models').factory('notificationGatewayProviderDisplayBu
                         }
                     } else {
                         results = genericModelBuilder.transform(jsonResult, Constructor);
-                        results.detachedDataValues = extendedDataDisplayBuilder.transform(jsonResult.detachedDataValues);
+                        if (jsonResult) {
+                            results.detachedDataValues = extendedDataDisplayBuilder.transform(jsonResult.detachedDataValues);
+                        }
                     }
                     return results;
                 }


### PR DESCRIPTION
The SalesByItem report was erroring due to the jsonResult object being null. An if check seems to fix this and now shows the chart.