### PR TITLE
Update PayPalExpressCheckoutPaymentGatewayMethod.cs

### DIFF
--- a/src/Merchello.Providers/Payment/PayPal/Provider/PayPalExpressCheckoutPaymentGatewayMethod.cs
+++ b/src/Merchello.Providers/Payment/PayPal/Provider/PayPalExpressCheckoutPaymentGatewayMethod.cs
@@ -151,15 +151,20 @@
             {
                 record = _paypalApiService.ExpressCheckout.Capture(invoice, payment, amount, isPartialPayment);
                 payment.SavePayPalTransactionRecord(record);
+                
+                if(record.Success)
+                {
+                    payment.Collected = (amount + applied) == payment.Amount;
+                    payment.Authorized = true;
 
-                payment.Collected = (amount + applied) == payment.Amount;
-                payment.Authorized = true;
+                    GatewayProviderService.Save(payment);
 
+                    GatewayProviderService.ApplyPaymentToInvoice(payment.Key, invoice.Key, AppliedPaymentType.Debit, "PayPal ExpressCheckout SUCCESS payment", amount);
+
+                    return new PaymentResult(Attempt<IPayment>.Succeed(payment), invoice, CalculateTotalOwed(invoice).CompareTo(amount) <= 0);
+                }
+                
                 GatewayProviderService.Save(payment);
-
-                GatewayProviderService.ApplyPaymentToInvoice(payment.Key, invoice.Key, AppliedPaymentType.Debit, "PayPal ExpressCheckout SUCCESS payment", amount);
-
-                return new PaymentResult(Attempt<IPayment>.Succeed(payment), invoice, CalculateTotalOwed(invoice).CompareTo(amount) <= 0);
             }
 
             return new PaymentResult(Attempt<IPayment>.Fail(payment), invoice, false);


### PR DESCRIPTION
After we try to Capture the payment with PayPalExpress we should validate if the record.Success == true before continuing with the rest of the logic.

We have, in our project, a few entries in the database where the Collected = 1 but the extendedData has "Success": false and "DoAtuhorization": { "Ack": 1 }, "DoCapture": { "Ack": 1 }