### PR TITLE
 missing check raiseEvents and  public GetCollectionsContaining with additional isfilter option

### DIFF
--- a/src/Merchello.Core/Services/EntityCollectionService.cs
+++ b/src/Merchello.Core/Services/EntityCollectionService.cs
@@ -682,7 +682,7 @@
                                      Name = name,
                                      ExtendedData = new ExtendedDataCollection()
                                  };
-
+            if (raiseEvents)
             if (Creating.IsRaisedEventCancelled(new Events.NewEventArgs<IEntityCollection>(collection), this))
             {
                 collection.WasCancelled = true;

--- a/src/Merchello.Web/Models/VirtualContent/ProductContentExtensions.cs
+++ b/src/Merchello.Web/Models/VirtualContent/ProductContentExtensions.cs
@@ -78,15 +78,18 @@
         /// <param name="product">
         /// The <see cref="IProductContent"/>.
         /// </param>
+        /// <param name="isFilter">
+        /// true to get all filters, false to get all collections
+        /// </param>
         /// <returns>
         /// The <see cref="IEnumerable{EntityCollectionDisplay}"/>.
         /// </returns>
-        public static IEnumerable<EntityCollectionDisplay> GetCollectionsContaining(this IProductContent product)
+        public static IEnumerable<EntityCollectionDisplay> GetCollectionsContaining(this IProductContent product, bool isFilter = false)
         {
             if (!MerchelloContext.HasCurrent) return Enumerable.Empty<EntityCollectionDisplay>();
             return
                 ((EntityCollectionService)MerchelloContext.Current.Services.EntityCollectionService)
-                    .GetEntityCollectionsByProductKey(product.Key).Select(x => x.ToEntityCollectionDisplay());
+                    .GetEntityCollectionsByProductKey(product.Key, isFilter).Select(x => x.ToEntityCollectionDisplay());
         }
 
         /// <summary>


### PR DESCRIPTION
the public GetCollectionsContaining with additional isfilter option commit in case want to print all selected filters of current Product to front-end:

```
var associatedFilterGroups = merchello.Filters.Product.GetFilterGroupsContainingProduct(Model.Key);
var currentFilters = Model.GetCollectionsContaining(true);
```
```
<p class="product-tag">
    <h5>Tags: </h5>
    @foreach (var filterGroup in associatedFilterGroups)
    {
        foreach (var filter in filterGroup.Filters)
        {
            if (currentFilters.Any(f => f.Key == filter.Key))
            {
            <a href="@filterPage.BuildTagUrl(filter.Key)">@filter.Name</a>
            }
        }
    }
</p>
```