### PR TITLE
Proposed fix to persisting inventory stock and low count

### DIFF
--- a/src/Merchello.Core/Persistence/Repositories/ProductOptionRepository.cs
+++ b/src/Merchello.Core/Persistence/Repositories/ProductOptionRepository.cs
@@ -115,7 +115,14 @@
             // Reset the Product Options Collection so that updated values are ordered and cached correctly
             product.ProductOptions = SaveForProduct(product.ProductOptions.AsEnumerable(), product.Key);
 
-            return product.ProductOptions.Where(x => x.Shared).Select(x => x.Key);
+            if (product.ProductOptions.Any())
+            {
+                return product.ProductOptions.Where(x => x.Shared).Select(x => x.Key);
+            }
+            else
+            {
+                return new List<Guid> { product.ProductVariantKey };
+            }
         }
 
         /// <summary>

--- a/src/Merchello.Core/Persistence/Repositories/ProductRepository.cs
+++ b/src/Merchello.Core/Persistence/Repositories/ProductRepository.cs
@@ -1967,7 +1967,9 @@
             // clear the cache for other products affected
             foreach (var key in productKeys)
             {
-                RuntimeCache.ClearCacheItem(Cache.CacheKeys.GetEntityCacheKey<IProduct>(key));
+				// clear cache item for both product and variant
+				RuntimeCache.ClearCacheItem(Cache.CacheKeys.GetEntityCacheKey<IProduct>(key));
+				RuntimeCache.ClearCacheItem(Cache.CacheKeys.GetEntityCacheKey<IProductVariant>(key));
             }
         }
     }

--- a/src/Merchello.Core/Persistence/Repositories/ProductVariantRepository.cs
+++ b/src/Merchello.Core/Persistence/Repositories/ProductVariantRepository.cs
@@ -245,6 +245,7 @@
             {
                 entity.ResetDirtyProperties();
                 RuntimeCache.ClearCacheItem(Cache.CacheKeys.GetEntityCacheKey<IProduct>(entity.ProductKey));
+				RuntimeCache.ClearCacheItem(Cache.CacheKeys.GetEntityCacheKey<IProductVariant>(entity.Key));
             }
         }
 
@@ -272,6 +273,7 @@
             {
                 entity.ResetDirtyProperties();
                 RuntimeCache.ClearCacheItem(Cache.CacheKeys.GetEntityCacheKey<IProduct>(entity.ProductKey));
+				RuntimeCache.ClearCacheItem(Cache.CacheKeys.GetEntityCacheKey<IProductVariant>(entity.Key));
             }
         }
 
@@ -898,7 +900,7 @@
 
             entity.ResetDirtyProperties();
 
-            RuntimeCache.ClearCacheItem(Cache.CacheKeys.GetEntityCacheKey<IProduct>(entity.ProductKey));
+            RemoveProductsFromRuntimeCache(new[] { entity.ProductKey });
         }
 
         /// <summary>
@@ -1172,6 +1174,7 @@
             foreach (var key in productKeys)
             {
                 RuntimeCache.ClearCacheItem(Cache.CacheKeys.GetEntityCacheKey<IProduct>(key));
+				RuntimeCache.ClearCacheItem(Cache.CacheKeys.GetEntityCacheKey<IProductVariant>(key));
             }
         }
     }

--- a/src/Merchello.Core/Services/ProductService.cs
+++ b/src/Merchello.Core/Services/ProductService.cs
@@ -294,7 +294,14 @@
 
             // save any remaining variants changes in the variants collection
             if (product.ProductVariants.Any())
-            _productVariantService.Save(product.ProductVariants, false);
+            {
+                _productVariantService.Save(product.ProductVariants, false);
+            }
+            else
+            {
+                // clear cache for product
+                MerchelloContext.Current.Cache.RuntimeCache.ClearCacheItem(Cache.CacheKeys.GetEntityCacheKey<IProduct>(product.Key));
+            }
 
             if (raiseEvents) Saved.RaiseEvent(new SaveEventArgs<IProduct>(product), this);
 
@@ -331,6 +338,19 @@
             // verify that all variants of these products still have attributes - or delete them
             productArray.ForEach(EnsureProductVariantsHaveAttributes);
 
+			foreach (var product in productArray)
+            {
+                if (product.ProductVariants.Any())
+                {
+                    _productVariantService.Save(product.ProductVariants, false);
+                }
+                else
+                {
+                    // clear cache for product
+                    MerchelloContext.Current.Cache.RuntimeCache.ClearCacheItem(Cache.CacheKeys.GetEntityCacheKey<IProduct>(product.Key));
+                }
+            }
+			
             if (raiseEvents) Saved.RaiseEvent(new SaveEventArgs<IProduct>(productArray), this);
         }
 

--- a/src/Merchello.Core/Services/ProductVariantService.cs
+++ b/src/Merchello.Core/Services/ProductVariantService.cs
@@ -241,6 +241,10 @@
                 }
             }
 
+			// clear caches
+            MerchelloContext.Current.Cache.RuntimeCache.ClearCacheItem(Cache.CacheKeys.GetEntityCacheKey<IProduct>(productVariant.ProductKey));
+            MerchelloContext.Current.Cache.RuntimeCache.ClearCacheItem(Cache.CacheKeys.GetEntityCacheKey<IProductVariant>(productVariant.Key));
+			
             if (raiseEvents)
                 Saved.RaiseEvent(new SaveEventArgs<IProductVariant>(productVariant), this);
         }
@@ -271,6 +275,13 @@
                 }
             }
 
+			foreach (var productVariant in productVariants)
+            {
+                // clear caches
+                MerchelloContext.Current.Cache.RuntimeCache.ClearCacheItem(Cache.CacheKeys.GetEntityCacheKey<IProduct>(productVariant.ProductKey));
+                MerchelloContext.Current.Cache.RuntimeCache.ClearCacheItem(Cache.CacheKeys.GetEntityCacheKey<IProductVariant>(productVariant.Key));
+            }
+			
             if (raiseEvents)
 
             Saved.RaiseEvent(new SaveEventArgs<IProductVariant>(productVariants), this);


### PR DESCRIPTION
These changes mainly concern clearing the product variants from the runtime cache whenever the regular products are cleared from the cache
The problem these changes are supposed to fix is described here:
https://our.umbraco.com/projects/collaboration/merchello/merchello/88376-problem-persisting-inventory-stock-and-low-count


Disclaimer: The changes I have made fixed the problem on my local, fresh 2.5.0 Merchello installation. I expect you may need to rewrite some of my proposed changes :)