### PR TITLE
Clone ExtendedData when using AsLineItemOf<T>

### DIFF
--- a/src/Merchello.Core/Extensions.ILineItem.cs
+++ b/src/Merchello.Core/Extensions.ILineItem.cs
@@ -51,7 +51,7 @@ namespace Merchello.Core
                     lineItem.Sku,
                     lineItem.Quantity,
                     lineItem.Price,
-                    lineItem.ExtendedData
+                    new ExtendedDataCollection(lineItem.ExtendedData)
                 };
 
 

--- a/src/Merchello.Core/Models/ExtendedDataCollection.cs
+++ b/src/Merchello.Core/Models/ExtendedDataCollection.cs
@@ -2,12 +2,14 @@
 {
     using System;
     using System.Collections.Concurrent;
+    using System.Collections.Generic;
     using System.Collections.Specialized;
     using System.IO;
     using System.Linq;
     using System.Runtime.Serialization;
     using System.Xml;
     using System.Xml.Linq;
+    using Umbraco.Core;
 
     /// <summary>
     /// Represents an ExtendedDataCollection
@@ -40,6 +42,20 @@
             foreach (var el in extendedData.Elements())
             {
                 SetValue(el.Name.LocalName, el.Value);                 
+            }
+        }
+        
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ExtendedDataCollection"/> class.
+        /// </summary>
+        /// <param name="dictionary">A dictionary with data to copy to the new collection</param>
+        internal ExtendedDataCollection(IDictionary<string, string> dictionary)
+        {
+            Mandate.ParameterNotNull(dictionary, "dictionary");
+
+            foreach(var pair in dictionary)
+            {
+                SetValue(pair.Key, pair.Value);
             }
         }
 


### PR DESCRIPTION
I've had multiple problems with the shared ExtendedData, after created new LineItem instances with AsLineItemOf, between the Basket and Invoice items. After the invoice is created and while it stays in cache, every change done in the basket item's extendedData is reflected in the corresponding invoice item. I really can't see an advantage in creating new instances of LineItem and keep sharing the extendedData object so, to fix my problems, I've created an extendedData clone so they can be totally independent objects.

I hope I exposed it clearly, if you need more details let me know.

Best regards.