### PR TITLE
Fix broken Reports query

### DIFF
--- a/src/Merchello.Core/Extensions.IProduct.cs
+++ b/src/Merchello.Core/Extensions.IProduct.cs
@@ -398,7 +398,7 @@ namespace Merchello.Core
         /// <returns>
         /// The <see cref="XDocument"/>.
         /// </returns>
-        internal static XDocument SerializeToXml(this IProductVariant productVariant, ProductOptionCollection productOptionCollection = null, IEnumerable<Guid> collections = null)
+        public static XDocument SerializeToXml(this IProductVariant productVariant, ProductOptionCollection productOptionCollection = null, IEnumerable<Guid> collections = null)
         {
             string xml;
             using (var sw = new StringWriter())

--- a/src/Merchello.Core/Models/Invoice.cs
+++ b/src/Merchello.Core/Models/Invoice.cs
@@ -571,7 +571,7 @@
 
         /// <inheritdoc/>
         [IgnoreDataMember]
-        internal int ExamineId
+        public int ExamineId
         {
             get { return _examineId; }
             set { _examineId = value; }

--- a/src/Merchello.Core/Models/Order.cs
+++ b/src/Merchello.Core/Models/Order.cs
@@ -215,7 +215,7 @@
 
         /// <inheritdoc/>
         [IgnoreDataMember]
-        internal int ExamineId
+        public int ExamineId
         {
             get { return _examineId; }
             set { _examineId = value; }

--- a/src/Merchello.Core/Persistence/Repositories/Interfaces/IDetachedContentTypeRepository.cs
+++ b/src/Merchello.Core/Persistence/Repositories/Interfaces/IDetachedContentTypeRepository.cs
@@ -10,7 +10,7 @@
     /// <summary>
     /// Marker interface for the DetachedContentTypeRepository.
     /// </summary>
-    internal interface IDetachedContentTypeRepository : IRepositoryQueryable<Guid, IDetachedContentType>
+    public interface IDetachedContentTypeRepository : IRepositoryQueryable<Guid, IDetachedContentType>
     {         
     }
 }

--- a/src/Merchello.Core/Persistence/Repositories/InvoiceRepository.cs
+++ b/src/Merchello.Core/Persistence/Repositories/InvoiceRepository.cs
@@ -855,8 +855,8 @@
 
                 sql.Append("SELECT SUM([merchInvoice].total) FROM merchInvoice WHERE [merchInvoice].invoiceDate BETWEEN @starts and @ends AND [merchInvoice].currencyCode = @cc", new
                 {
-                    @starts = startDate.GetDateForSqlStartOfDay(),
-                    @ends = endDate.GetDateForSqlEndOfDay(),
+                    @starts = startDate.GetStartOfDay(),//.GetDateForSqlStartOfDay(),
+                    @ends = endDate.GetEndOfDay(),//.GetDateForSqlEndOfDay(),
                     @cc = currencyCode
                 });
 
@@ -900,7 +900,11 @@
 
             return Database.ExecuteScalar<decimal>(
                 SQL,
-                new { @starts = startDate.GetDateForSqlStartOfDay(), @ends = endDate.GetDateForSqlEndOfDay(), @cc = currencyCode, @sku = sku });
+                new {
+                    @starts = startDate.GetStartOfDay(),//.GetDateForSqlStartOfDay(),
+                    @ends = endDate.GetEndOfDay(),//.GetDateForSqlEndOfDay(),
+                    @cc = currencyCode, @sku = sku
+                });
         }
 
         #region Filter Queries

--- a/src/Merchello.Core/Persistence/Repositories/MerchelloPetaPocoRepositoryBase.cs
+++ b/src/Merchello.Core/Persistence/Repositories/MerchelloPetaPocoRepositoryBase.cs
@@ -17,7 +17,7 @@
 	/// Represent an abstract Repository for PetaPoco based repositories
 	/// </summary>
 	/// <typeparam name="TEntity">The type of entity</typeparam>    
-    internal abstract class MerchelloPetaPocoRepositoryBase<TEntity> : MerchelloRepositoryBase<TEntity>
+    public abstract class MerchelloPetaPocoRepositoryBase<TEntity> : MerchelloRepositoryBase<TEntity>
 		where TEntity : class, IEntity
     {
         /// <summary>

--- a/src/Merchello.Core/Persistence/Repositories/MerchelloRepositoryBase.cs
+++ b/src/Merchello.Core/Persistence/Repositories/MerchelloRepositoryBase.cs
@@ -17,7 +17,7 @@
 	/// Represent an abstract Repository, which is the base of the Repository implementations
 	/// </summary>
 	/// <typeparam name="TEntity">Type of <see cref="IEntity"/> entity for which the repository is used</typeparam>
-	internal abstract class MerchelloRepositoryBase<TEntity> : DisposableObject, IRepositoryQueryable<Guid, TEntity>, IUnitOfWorkRepository 
+	public abstract class MerchelloRepositoryBase<TEntity> : DisposableObject, IRepositoryQueryable<Guid, TEntity>, IUnitOfWorkRepository 
 		where TEntity : class, IEntity
 	{
         /// <summary>

--- a/src/Merchello.Core/Persistence/Repositories/ProductOptionRepository.cs
+++ b/src/Merchello.Core/Persistence/Repositories/ProductOptionRepository.cs
@@ -29,7 +29,7 @@
     /// We have to be careful with the runtime cache here since various usages of the product option will be used by different products.
     /// We will need to make sure when we filter the choices, the object is previously cloned into a new option.
     /// </remarks>
-    internal class ProductOptionRepository : MerchelloPetaPocoRepositoryBase<IProductOption>, IProductOptionRepository
+    public class ProductOptionRepository : MerchelloPetaPocoRepositoryBase<IProductOption>, IProductOptionRepository
     {
         /// <summary>
         /// Valid sort fields.
@@ -85,7 +85,7 @@
         // TODO - this is a quick fix for an examine re-index issue where a shared product option is saved and individual products
         // that implement that option indexed values are not updated.
         // see: http://issues.merchello.com/youtrack/issue/M-1233
-        internal static event TypedEventHandler<ProductOptionRepository, ObjectEventArgs<IEnumerable<Guid>>>  ReIndex; 
+        public static event TypedEventHandler<ProductOptionRepository, ObjectEventArgs<IEnumerable<Guid>>>  ReIndex; 
 
         /// <summary>
         /// Saves options associated with a product.

--- a/src/Merchello.Core/Services/ShipmentService.cs
+++ b/src/Merchello.Core/Services/ShipmentService.cs
@@ -170,7 +170,7 @@
         /// <summary>
         /// Special event that fires when an order record is updated
         /// </summary>
-        internal static event TypedEventHandler<IShipmentService, SaveEventArgs<IOrder>> UpdatedOrder; 
+        public static event TypedEventHandler<IShipmentService, SaveEventArgs<IOrder>> UpdatedOrder; 
 
         #endregion
 

--- a/src/Merchello.Examine/Providers/CustomerIndexer.cs
+++ b/src/Merchello.Examine/Providers/CustomerIndexer.cs
@@ -63,7 +63,7 @@
         /// </summary>
         /// <param name="customer">The <see cref="ICustomer"/> to be indexed</param>
         /// <remarks>For testing</remarks>
-        internal void AddCustomerToIndex(ICustomer customer)
+        public void AddCustomerToIndex(ICustomer customer)
         {
             var nodes = new List<XElement> { customer.SerializeToXml().Root };
             AddNodesToIndex(nodes, IndexTypes.Customer);
@@ -74,7 +74,7 @@
         /// </summary>
         /// <param name="customer">The <see cref="ICustomer"/> to be removed from the index</param>
         /// <remarks>For testing</remarks>
-        internal void DeleteCustomerFromIndex(ICustomer customer)
+        public void DeleteCustomerFromIndex(ICustomer customer)
         {
             DeleteFromIndex(((Customer)customer).ExamineId.ToString(CultureInfo.InvariantCulture));
         }

--- a/src/Merchello.Examine/Providers/InvoiceIndexer.cs
+++ b/src/Merchello.Examine/Providers/InvoiceIndexer.cs
@@ -78,7 +78,7 @@
         /// </summary>
         /// <param name="invoice">The <see cref="IInvoice"/> to be indexed</param>
         /// <remarks>For testing</remarks>
-        internal void AddInvoiceToIndex(IInvoice invoice)
+        public void AddInvoiceToIndex(IInvoice invoice)
         {
             var nodes = new List<XElement> { invoice.SerializeToXml().Root };
             AddNodesToIndex(nodes, IndexTypes.Invoice);

--- a/src/Merchello.Examine/Providers/OrderIndexer.cs
+++ b/src/Merchello.Examine/Providers/OrderIndexer.cs
@@ -68,7 +68,7 @@
         /// <remarks>
         /// For testing
         /// </remarks>
-        internal void AddOrderToIndex(IOrder order)
+        public void AddOrderToIndex(IOrder order)
         {
             var nodes = new List<XElement> { order.SerializeToXml().Root };
             AddNodesToIndex(nodes, IndexTypes.Order);

--- a/src/Merchello.Examine/Providers/ProductIndexer.cs
+++ b/src/Merchello.Examine/Providers/ProductIndexer.cs
@@ -163,7 +163,7 @@
         /// <remarks>
         /// For testing
         /// </remarks>
-        internal void AddProductToIndex(IProduct product)
+        public void AddProductToIndex(IProduct product)
         {
             var nodes = new List<XElement>();
             nodes.AddRange(product.SerializeToXml().Descendants("productVariant"));
@@ -179,7 +179,7 @@
         /// <remarks>
         /// For testing
         /// </remarks>
-        internal void DeleteProductFromIndex(IProduct product)
+        public void DeleteProductFromIndex(IProduct product)
         {
             var ids = product.ProductVariants.Select(x => ((ProductVariant)x).ExamineId).ToList();
             ids.Add(((ProductVariant)((Product) product).MasterVariant).ExamineId);

--- a/src/Merchello.Web/Caching/VirtualContentCache{T}.cs
+++ b/src/Merchello.Web/Caching/VirtualContentCache{T}.cs
@@ -27,7 +27,7 @@
     /// <typeparam name="TEntity">
     /// The type of associated entity to be used in cache purges
     /// </typeparam>
-    internal abstract class VirtualContentCache<TContent, TEntity> : IVirtualContentCache<TContent, TEntity>
+    public abstract class VirtualContentCache<TContent, TEntity> : IVirtualContentCache<TContent, TEntity>
         where TContent : IPublishedContent
         where TEntity : IEntity
     {

--- a/src/Merchello.Web/Caching/VirtualProductContentCache.cs
+++ b/src/Merchello.Web/Caching/VirtualProductContentCache.cs
@@ -14,7 +14,7 @@
     /// <summary>
     /// A cache for <see cref="IProductContent"/>.
     /// </summary>
-    internal sealed class VirtualProductContentCache : VirtualContentCache<IProductContent, IProduct>, IVirtualProductContentCache
+    public sealed class VirtualProductContentCache : VirtualContentCache<IProductContent, IProduct>, IVirtualProductContentCache
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="VirtualProductContentCache"/> class.


### PR DESCRIPTION
For commit https://github.com/Merchello/Merchello/pull/2193/commits/1ccc3f8d0acb71d5b0d0888dd19eea604fdecb05,

After upgrading to 2.7.0, In Backoffice's Report view, all report pages are broken. The reason is that "GetDateForSqlEndOfDay()" return Date string like "27 October, 2018 12:39:00.000" which is not a ISO date recognized by Azure SQL server / MSSQL, thus throwing exception. 

We should just pass the DateTime object, and trust the native DateTime object conversion instead.