### PR TITLE
Typo in saleoverview.controller.js meant incorrect currency symbol used

### DIFF
--- a/src/Merchello.FastTrack.Ui/App_Plugins/Merchello/js/merchello.controllers.js
+++ b/src/Merchello.FastTrack.Ui/App_Plugins/Merchello/js/merchello.controllers.js
@@ -11147,7 +11147,7 @@ angular.module('merchello').controller('Merchello.Backoffice.OrderShipmentsContr
                    countries = combined.countries;
                    if ($scope.invoice.currency.symbol === '') {
                        var currency = _.find(combined.currencies, function (symbol) {
-                           return symbol.currecyCode === $scope.invoice.getCurrencyCode()
+                           return symbol.currencyCode === $scope.invoice.getCurrencyCode();
                        });
                        if (currency !== undefined) {
                            $scope.currencySymbol = currency.symbol;

--- a/src/Merchello.Web.UI.Client/src/views/sales/saleoverview.controller.js
+++ b/src/Merchello.Web.UI.Client/src/views/sales/saleoverview.controller.js
@@ -217,7 +217,7 @@
                    countries = combined.countries;
                    if ($scope.invoice.currency.symbol === '') {
                        var currency = _.find(combined.currencies, function (symbol) {
-                           return symbol.currecyCode === $scope.invoice.getCurrencyCode()
+                           return symbol.currencyCode === $scope.invoice.getCurrencyCode();
                        });
                        if (currency !== undefined) {
                            $scope.currencySymbol = currency.symbol;


### PR DESCRIPTION
Fixing issue #2208 

Sales listing correctly shows euro symbol:
![merchello-saleslisting-euro](https://user-images.githubusercontent.com/4716542/50548276-d6f07080-0c41-11e9-8984-724b16e51f8b.JPG)

Before bug fix done, sales overview showed base (£) symbol:
![merchello-salesoverview-bug](https://user-images.githubusercontent.com/4716542/50548286-f1c2e500-0c41-11e9-8500-2b165fc78b63.JPG)

After making this change and deploying the newly built merchello.controllers.js to my site:
![merchello-salesoverview-fixed](https://user-images.githubusercontent.com/4716542/50548300-30589f80-0c42-11e9-9b62-d9421e1ccca6.JPG)

