### PR TITLE
Ability to query products with a custom order by

### DIFF
--- a/src/Merchello.Core/Persistence/Repositories/ProductRepository.cs
+++ b/src/Merchello.Core/Persistence/Repositories/ProductRepository.cs
@@ -2544,9 +2544,19 @@
 
             if (!string.IsNullOrEmpty(orderExpression))
             {
-                sql.Append(sortDirection == SortDirection.Ascending
-                    ? string.Format("ORDER BY {0} ASC", orderExpression)
-                    : string.Format("ORDER BY {0} DESC", orderExpression));
+                if (orderExpression.StartsWith("ORDER BY"))
+                {
+                    var trimmedOrderBy = orderExpression.TrimEnd(" ASC").TrimEnd(" DESC");
+                    sql.Append(sortDirection == SortDirection.Ascending
+                        ? string.Format("{0} ASC", trimmedOrderBy)
+                        : string.Format("{0} DESC", trimmedOrderBy));
+                }
+                else
+                {
+                    sql.Append(sortDirection == SortDirection.Ascending
+                        ? string.Format("ORDER BY {0} ASC", orderExpression)
+                        : string.Format("ORDER BY {0} DESC", orderExpression));
+                }
             }
 
             return Database.Page<ProductVariantDto>(page, itemsPerPage, sql);

--- a/src/Merchello.Core/Persistence/Repositories/ProductRepository.cs
+++ b/src/Merchello.Core/Persistence/Repositories/ProductRepository.cs
@@ -2544,19 +2544,14 @@
 
             if (!string.IsNullOrEmpty(orderExpression))
             {
-                if (orderExpression.StartsWith("ORDER BY"))
+                if (orderExpression.StartsWith("ORDER BY", StringComparison.InvariantCultureIgnoreCase))
                 {
-                    var trimmedOrderBy = orderExpression.TrimEnd(" ASC").TrimEnd(" DESC");
-                    sql.Append(sortDirection == SortDirection.Ascending
-                        ? string.Format("{0} ASC", trimmedOrderBy)
-                        : string.Format("{0} DESC", trimmedOrderBy));
+                    orderExpression = orderExpression.TrimStart("ORDER BY").TrimEnd(" ASC").TrimEnd(" DESC").Trim();
                 }
-                else
-                {
-                    sql.Append(sortDirection == SortDirection.Ascending
+
+                sql.Append(sortDirection == SortDirection.Ascending
                         ? string.Format("ORDER BY {0} ASC", orderExpression)
                         : string.Format("ORDER BY {0} DESC", orderExpression));
-                }
             }
 
             return Database.Page<ProductVariantDto>(page, itemsPerPage, sql);

--- a/src/Merchello.Core/Services/ProductService.cs
+++ b/src/Merchello.Core/Services/ProductService.cs
@@ -2120,6 +2120,8 @@ namespace Merchello.Core.Services
         /// </returns>
         protected override string ValidateSortByField(string sortBy)
         {
+            if (sortBy.StartsWith("ORDER BY"))
+                return sortBy;
             return ValidSortFields.Contains(sortBy.ToLowerInvariant()) ? sortBy : "name";
         }
 

--- a/src/Merchello.Core/Services/ProductService.cs
+++ b/src/Merchello.Core/Services/ProductService.cs
@@ -2120,7 +2120,7 @@ namespace Merchello.Core.Services
         /// </returns>
         protected override string ValidateSortByField(string sortBy)
         {
-            if (sortBy.StartsWith("ORDER BY"))
+            if (sortBy.StartsWith("ORDER BY", StringComparison.InvariantCultureIgnoreCase))
                 return sortBy;
             return ValidSortFields.Contains(sortBy.ToLowerInvariant()) ? sortBy : "name";
         }

--- a/src/Merchello.Web/QueryBuilderExtensions.cs
+++ b/src/Merchello.Web/QueryBuilderExtensions.cs
@@ -187,6 +187,28 @@
         }
 
         /// <summary>
+        /// Sets the ordering of the query result.
+        /// </summary>
+        /// <param name="builder">
+        /// The builder.
+        /// </param>
+        /// <param name="orderByExpression">
+        /// The order by expression.
+        /// </param>
+        /// <param name="sortDirection">
+        /// The sort direction.
+        /// </param>
+        /// <returns>
+        /// The <see cref="IProductContentQueryBuilder"/>.
+        /// </returns>
+        public static IProductContentQueryBuilder OrderByCustomExpression(this IProductContentQueryBuilder builder, string orderByExpression, SortDirection sortDirection = SortDirection.Ascending)
+        {
+            builder.CustomOrderByExpression = orderByExpression;
+            builder.SortDirection = sortDirection;
+            return builder;
+        }
+
+        /// <summary>
         /// Sets a value indicating whether the query should be inclusive or exclusive with respect to the collection constraints.
         /// </summary>
         /// <param name="builder">

--- a/src/Merchello.Web/Search/CmsContentQueryBuilderBase.cs
+++ b/src/Merchello.Web/Search/CmsContentQueryBuilderBase.cs
@@ -49,6 +49,11 @@
         public string SearchTerm { get; set; }
 
         /// <summary>
+        /// Gets or sets the custom order by expression.
+        /// </summary>
+        public string CustomOrderByExpression { get; set; }
+
+        /// <summary>
         /// Gets or sets the sort by field.
         /// </summary>
         public ProductSortField SortBy { get; set; }

--- a/src/Merchello.Web/Search/ICmsContentQueryBuilder.cs
+++ b/src/Merchello.Web/Search/ICmsContentQueryBuilder.cs
@@ -91,6 +91,11 @@
         string SearchTerm { get; set; }
 
         /// <summary>
+        /// Gets or sets the custom order by expression.
+        /// </summary>
+        string CustomOrderByExpression { get; set; }
+
+        /// <summary>
         /// Gets or sets the sort by.
         /// </summary>
         ProductSortField SortBy { get; set; }

--- a/src/Merchello.Web/Search/ProductContentQueryBuilder.cs
+++ b/src/Merchello.Web/Search/ProductContentQueryBuilder.cs
@@ -85,6 +85,7 @@
         public override void Reset()
         {
             this.SearchTerm = string.Empty;
+            this.CustomOrderByExpression = string.Empty;
             this.Page = 1;
             this.ItemsPerPage = 10;
             this.SortBy = ProductSortField.Name;
@@ -113,6 +114,8 @@
         protected override ICmsContentQuery<IProductContent> Build()
         {
             var sortBy = SortBy.ToString().ToLowerInvariant();
+            if (!string.IsNullOrWhiteSpace(CustomOrderByExpression))
+                sortBy = CustomOrderByExpression;
 
             var query = new ProductContentQuery(_cachedQuery)
             {


### PR DESCRIPTION
A client of ours wants the ability to pick the order in which his products are displayed. To do so, we added a collection picker to the category to let them pick from a list of product keys. This PR then allows the ability to order by something of your choosing. In this case, a list of product keys.