### PR TITLE
Only show pre-determined dates when specified

### DIFF
--- a/src/Merchello.FastTrack.Ui/App_Plugins/Merchello/js/merchello.controllers.js
+++ b/src/Merchello.FastTrack.Ui/App_Plugins/Merchello/js/merchello.controllers.js
@@ -805,7 +805,8 @@ angular.module('merchello').controller('Merchello.Common.Dialogs.DateRangeSelect
 
                 // initial settings use standard
                 $scope.rangeStart = $filter('date')(start, $scope.settings.dateFormat);
-                $scope.rangeEnd =  $filter('date')(end, $scope.settings.dateFormat);
+                $scope.rangeEnd = $filter('date')(end, $scope.settings.dateFormat);
+                $scope.showPreDeterminedDates = showPreDeterminedDates;
 
                 setupDatePicker("#filterStartDate", $scope.rangeStart);
                 $element.find("#filterStartDate").datetimepicker().on("changeDate", applyDateStart);
@@ -10048,7 +10049,8 @@ angular.module('merchello').controller('Merchello.Backoffice.Reports.SalesOverTi
             function openDateRangeDialog() {
                 var dialogData = {
                     startDate: $scope.startDate,
-                    endDate: $scope.endDate
+                    endDate: $scope.endDate,
+                    showPreDeterminedDates: true
                 };
 
                 dialogService.open({
@@ -10196,7 +10198,8 @@ angular.module('merchello').controller('Merchello.Backoffice.Reports.SalesSearch
             function openDateRangeDialog() {
                 var dialogData = {
                     startDate: $scope.salesSearchSnapshot.startDate,
-                    endDate: $scope.salesSearchSnapshot.endDate
+                    endDate: $scope.salesSearchSnapshot.endDate,
+                    showPreDeterminedDates: true
                 };
 
                 dialogService.open({

--- a/src/Merchello.FastTrack.Ui/App_Plugins/Merchello/js/merchello.directives.js
+++ b/src/Merchello.FastTrack.Ui/App_Plugins/Merchello/js/merchello.directives.js
@@ -1581,7 +1581,8 @@ angular.module('merchello.directives').directive('merchelloDateRangeButton',
                 function openDateRangeDialog() {
                     var dialogData = {
                         startDate: scope.startDate,
-                        endDate: scope.endDate
+                        endDate: scope.endDate,
+                        showPreDeterminedDates: true
                     };
 
                     dialogService.open({
@@ -2134,7 +2135,8 @@ angular.module('merchello.directives').directive('merchelloListView',
                 function openDateRangeDialog() {
                     var dialogData = {
                         startDate: scope.startDate,
-                        endDate: scope.endDate
+                        endDate: scope.endDate,
+                        showPreDeterminedDates: true
                     };
 
                     dialogService.open({

--- a/src/Merchello.Web.UI.Client/src/views/common/dialogs/daterange.selection.controller.js
+++ b/src/Merchello.Web.UI.Client/src/views/common/dialogs/daterange.selection.controller.js
@@ -36,7 +36,8 @@ angular.module('merchello').controller('Merchello.Common.Dialogs.DateRangeSelect
 
                 // initial settings use standard
                 $scope.rangeStart = $filter('date')(start, $scope.settings.dateFormat);
-                $scope.rangeEnd =  $filter('date')(end, $scope.settings.dateFormat);
+                $scope.rangeEnd = $filter('date')(end, $scope.settings.dateFormat);
+                $scope.showPreDeterminedDates = showPreDeterminedDates;
 
                 setupDatePicker("#filterStartDate", $scope.rangeStart);
                 $element.find("#filterStartDate").datetimepicker().on("changeDate", applyDateStart);

--- a/src/Merchello.Web.UI.Client/src/views/common/dialogs/daterange.selection.html
+++ b/src/Merchello.Web.UI.Client/src/views/common/dialogs/daterange.selection.html
@@ -9,7 +9,7 @@
 
             <div class="umb-overlay-container form-horizontal merchello-panel-body">
 
-                <div class="form-group control-group">
+                <div class="form-group control-group" ng-show="showPreDeterminedDates">
                     <p><localize key="merchelloGeneral_preDeterminedDateRange">Select a pre-determined date range:</localize></p>
                     <ul style="list-style:none;margin:0;padding:0;display:inline;">
                         <li>
@@ -25,7 +25,7 @@
                 </div>  
 
                 <div class="form-group control-group">
-                    <p><localize key="merchelloGeneral_customDateRange">Or choose a custom date range:</localize></p>
+                    <p ng-show="showPreDeterminedDates"><localize key="merchelloGeneral_customDateRange">Or choose a custom date range:</localize></p>
                     <div class="input-append date datepicker" id="filterStartDate">
                         <label><localize key="merchelloGeneral_starting">Starting</localize></label>
                         <input name="datepicker" data-ng-format="dateFormat" type="text" data-ng-model="rangeStart" />

--- a/src/Merchello.Web.UI.Client/src/views/directives/merchello.daterangebutton.directive.js
+++ b/src/Merchello.Web.UI.Client/src/views/directives/merchello.daterangebutton.directive.js
@@ -62,7 +62,8 @@ angular.module('merchello.directives').directive('merchelloDateRangeButton',
                 function openDateRangeDialog() {
                     var dialogData = {
                         startDate: scope.startDate,
-                        endDate: scope.endDate
+                        endDate: scope.endDate,
+                        showPreDeterminedDates: true
                     };
 
                     dialogService.open({

--- a/src/Merchello.Web.UI.Client/src/views/directives/merchellolistview.directive.js
+++ b/src/Merchello.Web.UI.Client/src/views/directives/merchellolistview.directive.js
@@ -271,7 +271,8 @@ angular.module('merchello.directives').directive('merchelloListView',
                 function openDateRangeDialog() {
                     var dialogData = {
                         startDate: scope.startDate,
-                        endDate: scope.endDate
+                        endDate: scope.endDate,
+                        showPreDeterminedDates: true
                     };
 
                     dialogService.open({

--- a/src/Merchello.Web.UI.Client/src/views/reports/salesSearch.controller.js
+++ b/src/Merchello.Web.UI.Client/src/views/reports/salesSearch.controller.js
@@ -94,7 +94,8 @@ angular.module('merchello').controller('Merchello.Backoffice.Reports.SalesSearch
             function openDateRangeDialog() {
                 var dialogData = {
                     startDate: $scope.salesSearchSnapshot.startDate,
-                    endDate: $scope.salesSearchSnapshot.endDate
+                    endDate: $scope.salesSearchSnapshot.endDate,
+                    showPreDeterminedDates: true
                 };
 
                 dialogService.open({


### PR DESCRIPTION
The quick date selectors were showing when irrelevant - e.g. coupon active offer dates