### PR TITLE
Trigger the SMTP Email Notification for OrderShipped when a Shipment …

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -219,3 +219,6 @@ src/Merchello.FastTrack.Ui/App_Data/umbraco.config
 src/Merchello.Core/App_Data/NuGetBackup/
 src/Merchello.Web/App_Data/NuGetBackup/
 src/Merchello.FastTrack.Ui/App_Data/TEMP/ClientDependency/*
+/src/Merchello.FastTrack.Ui/bin/Microsoft.Web.Helpers.dll
+/src/Merchello.FastTrack.Ui/bin/System.Net.Http.Extensions.dll
+/src/Merchello.FastTrack.Ui/bin/System.Net.Http.Primitives.dll

--- a/src/Merchello.Core/Gateways/Shipping/ShippingEvents.cs
+++ b/src/Merchello.Core/Gateways/Shipping/ShippingEvents.cs
@@ -1,0 +1,60 @@
+﻿using Merchello.Core.Models;
+using Merchello.Core.Services;
+using System.Linq;
+using Umbraco.Core;
+using Merchello.Core.Events;
+using Umbraco.Core.Logging;
+using log4net;
+using System.Reflection;
+using System.Collections.Generic;
+
+namespace Merchello.Core.Gateways.Shipping
+{
+    /// <summary>
+    /// Represents the ShippingContext
+    /// </summary>
+    public class ShippingEvents : ApplicationEventHandler
+    {
+        private static readonly ILog Log = LogManager.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
+
+        /// <summary>
+        /// Trigger the SMTP Email Notification for OrderShipped when a Shipment has changed its status to Shipped and/or Delivered.
+        /// This will normally result in 2 emails - 1 when the item is shipped, and 1 when it is subsequently delivered.
+        /// Note: A CHANGE to the status is required - so the initial ShipmentStatus must NOT be in one of these states.
+        /// The OrderShipped.cshtml file examines the shipping state and informs the recipient if the item has been shipped or delivered.
+        /// </summary>
+        /// <param name="umbracoApplication"></param>
+        /// <param name="applicationContext"></param>
+        protected override void ApplicationStarted(UmbracoApplicationBase umbracoApplication, ApplicationContext applicationContext)
+        {
+            base.ApplicationStarted(umbracoApplication, applicationContext);
+            Log.Info("Setting up Shipment Service, Status Changed processing.");
+            ShipmentService.StatusChanged += ShipmentServiceStatusChanged;
+        }
+
+        private void ShipmentServiceStatusChanged(IShipmentService sender, StatusChangeEventArgs<IShipment> e)
+        {
+
+            var validKeys = new[]
+                            {
+                            Merchello.Core.Constants.ShipmentStatus.Delivered,
+                            Merchello.Core.Constants.ShipmentStatus.Shipped
+                        };
+
+            foreach (var shipment in e.StatusChangedEntities)
+            {
+
+                if (!validKeys.Contains(shipment.ShipmentStatus.Key)) continue;
+
+                Log.Info(string.Format("Raising 'OrderShipped' notification trigger for shipment no. {0} to {1}", shipment.ShipmentNumber, shipment.Email));
+
+                var contact = new List<string>() { shipment.Email };
+
+                Merchello.Core.Notification.Trigger("OrderShipped", shipment, contact, Merchello.Core.Observation.Topic.Notifications);
+            }
+        }
+    }
+
+    
+    
+}

--- a/src/Merchello.Core/Merchello.Core.csproj
+++ b/src/Merchello.Core/Merchello.Core.csproj
@@ -517,6 +517,7 @@
     <Compile Include="Extensions.Version.cs">
       <DependentUpon>Extensions.cs</DependentUpon>
     </Compile>
+    <Compile Include="Gateways\Shipping\ShippingEvents.cs" />
     <Compile Include="Logging\IRemoteLogger.cs" />
     <Compile Include="Models\DetachedContent\DetachedContentValuesSerializationHelper.cs" />
     <Compile Include="Models\EntityBase\IDateStamped.cs" />

--- a/src/Merchello.FastTrack.Ui/Views/Merchello/Notification/OrderConfirmation.cshtml
+++ b/src/Merchello.FastTrack.Ui/Views/Merchello/Notification/OrderConfirmation.cshtml
@@ -6,6 +6,10 @@
      Example usage:  var product = Merchello.TypedProductContent(YOURPRODUCTKEY);
 *@
 @{
+    // Avoid any impact from a Layout assigned in the _ViewStart.cshtml
+    // If such a Layout is assigned and it is derived from UmbracoTemplatePage
+    // it will cause a model binding error.
+    Layout = null;
     var invoice = Model.Invoice;
     var billingAddress = invoice.GetBillingAddress();
     var customerName = billingAddress.Name;

--- a/src/Merchello.FastTrack.Ui/Views/Merchello/Notification/OrderShipped.cshtml
+++ b/src/Merchello.FastTrack.Ui/Views/Merchello/Notification/OrderShipped.cshtml
@@ -3,23 +3,18 @@
 @using Merchello.Core.Models
 @using Merchello.FastTrack.Factories
 @*
-     MerchelloHelperViewPage<T> inherits from UmbracoViewPage<t> and exposes the MerchelloHelper as 'Merchello'
-     Example usage:  var product = Merchello.TypedProductContent(YOURPRODUCTKEY);
+    MerchelloHelperViewPage<T> inherits from UmbracoViewPage<t> and exposes the MerchelloHelper as 'Merchello'
+    Example usage:  var product = Merchello.TypedProductContent(YOURPRODUCTKEY);
+    Note: This exposure of Merchello causes ambiguity with the Merchello.Core namespace hence use of global:: below.
 *@
-
 @{
+    Layout = null; // Avoid using the Master.cshtml layout which inherits from UmbracoTemplatePage and hence RenderModel
     var destination = Model.Shipment.GetDestinationAddress();
 
 }
-
 <p>Dear @Model.Invoice.BillToName</p>
-
-
-
-<p>We have just shipped the following order:</p>
-
+<p>We have just @(Model.Shipment.ShipmentStatus.Key == global::Merchello.Core.Constants.ShipmentStatus.Shipped ? "shipped" : "delivered") the following order:</p>
 @Html.Partial("_Address", destination)
-
 <table>
     <tr>
         <td>Invoice No:</td>


### PR DESCRIPTION
…has changed its status to Shipped and/or Delivered.

This will normally result in 2 emails - 1 when the item is shipped, and 1 when it is subsequently delivered.
Note: A CHANGE to the status is required - so the initial ShipmentStatus must NOT be in one of these states.
The OrderShipped.cshtml file examines the shipping state and informs the recipient if the item has been shipped or delivered.

The notification razor files have Layout set to null to avoid causing model binding errors when a Layout is assigned in the _ViewStart.cshtml file.
The OrderShipped razor file also notifies the reader if the email is related to an item that has been shipped or delivered.