### PR TITLE
Update VirtualProductContentCache.cs

### DIFF
--- a/src/Merchello.Web/Caching/VirtualProductContentCache.cs
+++ b/src/Merchello.Web/Caching/VirtualProductContentCache.cs
@@ -31,7 +31,8 @@
         /// <returns></returns>
         private IProductContent UpdateLanguage(IProductContent content)
         {
-            content?.SpecifyCulture(System.Threading.Thread.CurrentThread.CurrentUICulture);
+            if(null != content)
+                content.SpecifyCulture(System.Threading.Thread.CurrentThread.CurrentUICulture);
             return content;
         }
 

--- a/src/Merchello.Web/Caching/VirtualProductContentCache.cs
+++ b/src/Merchello.Web/Caching/VirtualProductContentCache.cs
@@ -25,6 +25,17 @@
         }
 
         /// <summary>
+        /// Changes the product display content by ui culture.
+        /// </summary>
+        /// <param name="content"></param>
+        /// <returns></returns>
+        private IProductContent UpdateLanguage(IProductContent content)
+        {
+            content?.SpecifyCulture(System.Threading.Thread.CurrentThread.CurrentUICulture);
+            return content;
+        }
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="VirtualProductContentCache"/> class.
         /// </summary>
         /// <param name="cache">
@@ -82,9 +93,9 @@
         {
             var cacheKey = GetSlugCacheKey(slug, ModifiedVersion);
             var content = (IProductContent)Cache.RuntimeCache.GetCacheItem(cacheKey);
-            if (content != null) return content;
+            if (content != null) return UpdateLanguage(content);
 
-            return CacheContent(cacheKey, get.Invoke(slug));
+            return UpdateLanguage(CacheContent(cacheKey, get.Invoke(slug)));
         }
 
         /// <summary>
@@ -101,11 +112,11 @@
         /// </returns>
         public IProductContent GetBySku(string sku, Func<string, IProductContent> get)
         {
-            var cacheKey = GetSkuCacheKey(sku, ModifiedVersion);
+             var cacheKey = GetSkuCacheKey(sku, ModifiedVersion);
             var content = (IProductContent)Cache.RuntimeCache.GetCacheItem(cacheKey);
-            if (content != null) return content;
+            if (content != null) return UpdateLanguage(content);
 
-            return CacheContent(cacheKey, get.Invoke(sku));
+            return UpdateLanguage(CacheContent(cacheKey, get.Invoke(sku)));
         }
 
         /// <summary>


### PR DESCRIPTION
Added method so the UI culture is preserved on cached products.

The UI culture is not respected as it should be.
The problem raised in the caching of the products.
I have added a method in the VirtualProductContentCache so it respect the current set UI Colture. 

The problem manifests itself like this.

We have a site with two or more products
[en]/ -> Product is displayed in en
[de]/ -> As the product is cached the product is displayed in EN again

With this fix, the product is displayed as it should be.

I hope this do not break anything.

