### PR TITLE
Adding Default Variant

### DIFF
--- a/src/Merchello.Core/Merchello.Core.csproj
+++ b/src/Merchello.Core/Merchello.Core.csproj
@@ -527,6 +527,7 @@
     <Compile Include="Persistence\Migrations\Upgrades\TargetVersionTwoFiveZero\AddIndexesToInvoice.cs" />
     <Compile Include="Persistence\Migrations\Upgrades\TargetVersionTwoFiveZero\AddIndexesToProductVariant.cs" />
     <Compile Include="Persistence\Migrations\Upgrades\TargetVersionTwoFourZero\AddShipmentTrackingUrlColumns.cs" />
+    <Compile Include="Persistence\Migrations\Upgrades\TargetVersionTwoSevenTwo\AddIsDefaultColumn.cs" />
     <Compile Include="Persistence\Migrations\Upgrades\TargetVersionTwoThreeOne\AlterProductAttributeColumnToNtext.cs" />
     <Compile Include="Persistence\Repositories\Interfaces\IProductBackOfficeRepository.cs" />
     <Compile Include="Persistence\Repositories\Interfaces\IPortForwardProductRepository.cs" />

--- a/src/Merchello.Core/Models/Interfaces/IProductBase.cs
+++ b/src/Merchello.Core/Models/Interfaces/IProductBase.cs
@@ -131,7 +131,6 @@
         [DataMember]
         int? DownloadMediaId { get; set; }
 
-
         /// <summary>
         /// Gets the version key.
         /// </summary>

--- a/src/Merchello.Core/Models/Interfaces/IProductVariant.cs
+++ b/src/Merchello.Core/Models/Interfaces/IProductVariant.cs
@@ -38,5 +38,10 @@
         /// Gets a value indicating whether this represents the master product variant.
         /// </summary>
         bool Master { get; }
+
+        /// <summary>
+        /// Gets a value indicating whether this variant is the default variant to display
+        /// </summary>
+        bool IsDefault { get; set; }
     }
 }

--- a/src/Merchello.Core/Models/ProductVariant.cs
+++ b/src/Merchello.Core/Models/ProductVariant.cs
@@ -7,7 +7,7 @@
     using System.Reflection;
     using System.Runtime.Serialization;
 
-    using Merchello.Core.Models.DetachedContent;
+    using DetachedContent;
 
     /// <summary>
     /// Defines a product variant
@@ -38,6 +38,11 @@
         private bool _master;
 
         /// <summary>
+        /// The value indicating whether or not this is the default variant to display
+        /// </summary>
+        private bool _isDefault;
+
+        /// <summary>
         /// The examine id.
         /// </summary>
         private int _examineId = 1;
@@ -57,7 +62,7 @@
         /// The price.
         /// </param>
         internal ProductVariant(string name, string sku, decimal price)
-            : this(Guid.Empty, new ProductAttributeCollection(), new CatalogInventoryCollection(), false, name, sku, price)
+            : this(Guid.Empty, new ProductAttributeCollection(), new CatalogInventoryCollection(), false, false, name, sku, price)
         {            
         }
 
@@ -85,7 +90,7 @@
             string name,
             string sku,
             decimal price)
-            : this(productKey, attributes, new CatalogInventoryCollection(), false, name, sku, price)
+            : this(productKey, attributes, new CatalogInventoryCollection(), false, false, name, sku, price)
         {            
         }
 
@@ -117,7 +122,7 @@
             string name,
             string sku,
             decimal price)
-            : this(productKey, attributes, catalogInventoryCollection, false, name, sku, price)
+            : this(productKey, attributes, catalogInventoryCollection, false, false, name, sku, price)
         {            
         }
 
@@ -136,6 +141,7 @@
         /// <param name="master">
         /// The master.
         /// </param>
+        /// <param name="isDefault"></param>
         /// <param name="name">
         /// The name.
         /// </param>
@@ -145,8 +151,8 @@
         /// <param name="price">
         /// The price.
         /// </param>
-        internal ProductVariant(Guid productKey, ProductAttributeCollection attributes, CatalogInventoryCollection catalogInventoryCollection, bool master, string name, string sku, decimal price)
-            : this(productKey, attributes, catalogInventoryCollection, new DetachedContentCollection<IProductVariantDetachedContent>(), false, name, sku, price)
+        internal ProductVariant(Guid productKey, ProductAttributeCollection attributes, CatalogInventoryCollection catalogInventoryCollection, bool master, bool isDefault, string name, string sku, decimal price)
+            : this(productKey, attributes, catalogInventoryCollection, new DetachedContentCollection<IProductVariantDetachedContent>(), master, isDefault, name, sku, price)
         {
         }
 
@@ -168,6 +174,9 @@
         /// <param name="master">
         /// The master.
         /// </param>
+        /// <param name="isDefault">
+        /// The isDefault
+        /// </param>
         /// <param name="name">
         /// The name.
         /// </param>
@@ -177,7 +186,7 @@
         /// <param name="price">
         /// The price.
         /// </param>
-        internal ProductVariant(Guid productKey, ProductAttributeCollection attributes, CatalogInventoryCollection catalogInventoryCollection, DetachedContentCollection<IProductVariantDetachedContent> detachedContents,  bool master, string name, string sku, decimal price)
+        internal ProductVariant(Guid productKey, ProductAttributeCollection attributes, CatalogInventoryCollection catalogInventoryCollection, DetachedContentCollection<IProductVariantDetachedContent> detachedContents,  bool master, bool isDefault, string name, string sku, decimal price)
             : base(name, sku, price, catalogInventoryCollection, detachedContents)
         {
             Ensure.ParameterNotNull(attributes, "attributes");
@@ -247,6 +256,21 @@
         }
 
         /// <inheritdoc/>
+        [DataMember]
+        public bool IsDefault
+        {
+            get
+            {
+                return _isDefault;
+            }
+
+            set
+            {
+                SetPropertyValueAndDetectChanges(value, ref _isDefault, _ps.Value.IsDefaultSelector);
+            }
+        }
+
+        /// <inheritdoc/>
         [IgnoreDataMember]
         internal ProductAttributeCollection ProductAttributes
         {
@@ -290,6 +314,11 @@
             /// The master selector.
             /// </summary>
             public readonly PropertyInfo MasterSelector = ExpressionHelper.GetPropertyInfo<ProductVariant, bool>(x => x.Master);
+
+            /// <summary>
+            /// The default selector.
+            /// </summary>
+            public readonly PropertyInfo IsDefaultSelector = ExpressionHelper.GetPropertyInfo<ProductVariant, bool>(x => x.IsDefault);
 
             /// <summary>
             /// The attributes changed selector.

--- a/src/Merchello.Core/Models/Rdbms/ProductVariantDto.cs
+++ b/src/Merchello.Core/Models/Rdbms/ProductVariantDto.cs
@@ -178,6 +178,12 @@
         [Constraint(Default = "0")]
         public bool Master { get; set; }
 
+        /// <summary>
+        /// Gets or sets a value indicating whether this variant is the default variant
+        /// </summary>
+        [Column("isDefault")]
+        [Constraint(Default = "0")]
+        public bool IsDefault { get; set; }
 
         /// <summary>
         /// Gets or sets the version key.

--- a/src/Merchello.Core/Persistence/Factories/ProductVariantFactory.cs
+++ b/src/Merchello.Core/Persistence/Factories/ProductVariantFactory.cs
@@ -87,6 +87,7 @@
                 Download = dto.Download,
                 DownloadMediaId = dto.DownloadMediaId,
                 Master = dto.Master,
+                IsDefault = dto.IsDefault,
                 ExamineId = dto.ProductVariantIndexDto.Id, 
                 CatalogInventoryCollection = _catalogInventories,
                 ProductAttributes = _productAttributeCollection,
@@ -127,6 +128,7 @@
                 Download = entity.Download,
                 DownloadMediaId = entity.DownloadMediaId,
                 Master = ((ProductVariant)entity).Master,
+                IsDefault = ((ProductVariant)entity).IsDefault,
                 ProductVariantIndexDto = new ProductVariantIndexDto()
                     {
                       Id = ((ProductVariant)entity).ExamineId,

--- a/src/Merchello.Core/Persistence/Migrations/Upgrades/TargetVersionTwoSevenTwo/AddIsDefaultColumn.cs
+++ b/src/Merchello.Core/Persistence/Migrations/Upgrades/TargetVersionTwoSevenTwo/AddIsDefaultColumn.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using System.Linq;
+using Merchello.Core.Configuration;
+using Umbraco.Core;
+using Umbraco.Core.Persistence.Migrations;
+
+namespace Merchello.Core.Persistence.Migrations.Upgrades.TargetVersionTwoSevenTwo
+{
+    /// <summary>
+    ///     Adds new IsDefault column to product variants which makes it easier to display the default selected variant
+    /// </summary>
+    [Migration("2.7.2", 1, MerchelloConfiguration.MerchelloMigrationName)]
+    public class AddIsDefaultColumn : MerchelloMigrationBase, IMerchelloMigration
+    {
+        /// <summary>
+        /// </summary>
+        /// <exception cref="NotImplementedException"></exception>
+        public override void Up()
+        {
+            var database = ApplicationContext.Current.DatabaseContext.Database;
+            var columns = SqlSyntax.GetColumnsInSchema(database).ToArray();
+
+            // 'isDefault' column
+            if (columns.Any(x => x.TableName.InvariantEquals("merchProductVariant") && x.ColumnName.InvariantEquals("isDefault")) == false)
+            {
+                Logger.Info(typeof(AddIsDefaultColumn), "Adding IsDefault column to merchProductVariant table.");
+
+                //// Add the new 'isDefaultChoice' column
+                Create.Column("isDefault").OnTable("merchProductVariant").AsBoolean().WithDefaultValue(false);
+            }
+        }
+
+        /// <summary>
+        ///     Downgrades the database.
+        /// </summary>
+        /// <exception cref="DataLossException"></exception>
+        public override void Down()
+        {
+            throw new DataLossException(
+                "Cannot downgrade from version 2.7.2 database to a prior version, the database schema has already been modified");
+        }
+    }
+}

--- a/src/Merchello.Core/Services/Interfaces/IProductVariantService.cs
+++ b/src/Merchello.Core/Services/Interfaces/IProductVariantService.cs
@@ -68,6 +68,14 @@
         IProductVariant GetByKey(Guid key);
 
         /// <summary>
+        /// Gets a collection of all <see cref="IProductVariant"/>.
+        /// </summary>
+        /// <returns>
+        /// The collection of all <see cref="IProductVariant"/>.
+        /// </returns>
+        IEnumerable<IProductVariant> GetAll();
+
+        /// <summary>
         /// Gets an <see cref="IProductVariant"/> object by it's unique SKU.
         /// </summary>
         /// <param name="sku">

--- a/src/Merchello.Web/AutoMapperMappings-WarehouseProducts.cs
+++ b/src/Merchello.Web/AutoMapperMappings-WarehouseProducts.cs
@@ -1,55 +1,52 @@
-﻿namespace Merchello.Web
+﻿using AutoMapper;
+using Merchello.Core.Models;
+using Merchello.Web.Models.ContentEditing;
+using Merchello.Web.Models.MapperResolvers;
+using Merchello.Web.Models.MapperResolvers.DetachedContent;
+using Merchello.Web.Models.MapperResolvers.ProductOptions;
+
+namespace Merchello.Web
 {
-    using System.Linq.Expressions;
-    using Core.Models;
-    using Core.Models.Interfaces;
-
-    using Merchello.Core.Models.DetachedContent;
-    using Merchello.Web.Models.ContentEditing.Content;
-    using Merchello.Web.Models.MapperResolvers.DetachedContent;
-    using Merchello.Web.Models.MapperResolvers.Offers;
-    using Merchello.Web.Models.MapperResolvers.ProductOptions;
-
-    using Models.ContentEditing;
-    using Models.MapperResolvers;
-
     /// <summary>
-    /// Binds Merchello AutoMapper mappings during the Umbraco startup.
+    ///     Binds Merchello AutoMapper mappings during the Umbraco startup.
     /// </summary>
     internal static partial class AutoMapperMappings
     {
         /// <summary>
-        /// Creates warehouse and product mappings.
+        ///     Creates warehouse and product mappings.
         /// </summary>
         private static void CreateWarehouseAndProductMappings()
         {
             // warehouse
-            AutoMapper.Mapper.CreateMap<IWarehouse, WarehouseDisplay>();
-            AutoMapper.Mapper.CreateMap<IWarehouseCatalog, WarehouseCatalogDisplay>()
-                 .ForMember(dest => dest.IsDefault, opt => opt.ResolveUsing<WarehouseCatalogIsDefaultResolver>().ConstructedBy(() => new WarehouseCatalogIsDefaultResolver()));
+            Mapper.CreateMap<IWarehouse, WarehouseDisplay>();
+            Mapper.CreateMap<IWarehouseCatalog, WarehouseCatalogDisplay>()
+                .ForMember(dest => dest.IsDefault,
+                    opt => opt.ResolveUsing<WarehouseCatalogIsDefaultResolver>()
+                        .ConstructedBy(() => new WarehouseCatalogIsDefaultResolver()));
 
             // products
-            AutoMapper.Mapper.CreateMap<IProduct, ProductDisplay>();
-            AutoMapper.Mapper.CreateMap<IProductVariant, ProductVariantDisplay>();
+            Mapper.CreateMap<IProduct, ProductDisplay>();
+            Mapper.CreateMap<IProductVariant, ProductVariantDisplay>();
 
-            AutoMapper.Mapper.CreateMap<ProductDisplay, ProductVariantDisplay>()
+            Mapper.CreateMap<ProductDisplay, ProductVariantDisplay>()
                 .ForMember(dest => dest.Key, opt => opt.MapFrom(x => x.ProductVariantKey))
                 .ForMember(dest => dest.ProductKey, opt => opt.MapFrom(x => x.Key));
-           
-            AutoMapper.Mapper.CreateMap<IProductAttribute, ProductAttributeDisplay>()
+
+            Mapper.CreateMap<IProductAttribute, ProductAttributeDisplay>()
                 .ForMember(
                     dest => dest.DetachedDataValues,
                     opt =>
-                    opt.ResolveUsing<ProductAttributeDetachedDataValuesResolver>().ConstructedBy(() => new ProductAttributeDetachedDataValuesResolver()));
+                        opt.ResolveUsing<ProductAttributeDetachedDataValuesResolver>()
+                            .ConstructedBy(() => new ProductAttributeDetachedDataValuesResolver()));
 
-            AutoMapper.Mapper.CreateMap<IProductOption, ProductOptionDisplay>()
+            Mapper.CreateMap<IProductOption, ProductOptionDisplay>()
                 .ForMember(
                     dest => dest.ShareCount,
                     opt =>
-                    opt.ResolveUsing<ProductOptionSharedCountResolver>()
-                        .ConstructedBy(() => new ProductOptionSharedCountResolver()));
+                        opt.ResolveUsing<ProductOptionSharedCountResolver>()
+                            .ConstructedBy(() => new ProductOptionSharedCountResolver()));
 
-            AutoMapper.Mapper.CreateMap<ICatalogInventory, CatalogInventoryDisplay>();            
+            Mapper.CreateMap<ICatalogInventory, CatalogInventoryDisplay>();
         }
     }
 }

--- a/src/Merchello.Web/Models/ContentEditing/ExamineDisplayExtensions.cs
+++ b/src/Merchello.Web/Models/ContentEditing/ExamineDisplayExtensions.cs
@@ -89,7 +89,8 @@
                 UpdateDate = FieldAsDateTime(result, "updateDate"),
                 Attributes = RawJsonFieldAsCollection<ProductAttributeDisplay>(result, "attributes"),
                 CatalogInventories = RawJsonFieldAsCollection<CatalogInventoryDisplay>(result, "catalogInventories"),
-                DetachedContents = GetProductVariantDetachedContentDisplayCollection(result, "detachedContents")
+                DetachedContents = GetProductVariantDetachedContentDisplayCollection(result, "detachedContents"),
+                IsDefault = FieldAsBoolean(result.Fields["isDefault"])
             };
             return pvd;
         }
@@ -394,7 +395,12 @@
         /// </returns>
         public static bool FieldAsBoolean(string value)
         {
-            return string.Equals("True", value);
+            if (!string.IsNullOrWhiteSpace(value))
+            {
+                return string.Equals("True", value.Trim());
+            }
+
+            return false;
         }
 
         /// <summary>

--- a/src/Merchello.Web/Models/ContentEditing/ProductDisplayExtensions.cs
+++ b/src/Merchello.Web/Models/ContentEditing/ProductDisplayExtensions.cs
@@ -851,6 +851,7 @@
             destination.DownloadMediaId = productVariantDisplay.DownloadMediaId;
 
             destination.ProductKey = productVariantDisplay.ProductKey;
+            destination.IsDefault = productVariantDisplay.IsDefault;
 
             // We need to refactor the CatalogInventories to not be immutable if we are
             // going to need to do operations like this.  In the UI, the user "unchecks" a catalog that was

--- a/src/Merchello.Web/Models/ContentEditing/ProductVariantDisplay.cs
+++ b/src/Merchello.Web/Models/ContentEditing/ProductVariantDisplay.cs
@@ -2,7 +2,6 @@
 {
     using System;
     using System.Collections.Generic;
-    using System.Linq;
 
     /// <summary>
     /// The product variant display.
@@ -23,5 +22,10 @@
         /// Gets or sets the attributes.
         /// </summary>
         public IEnumerable<ProductAttributeDisplay> Attributes { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether master.
+        /// </summary>
+        public bool IsDefault { get; set; }
     }
 }

--- a/src/Merchello.Web/Models/VirtualContent/IProductVariantContent.cs
+++ b/src/Merchello.Web/Models/VirtualContent/IProductVariantContent.cs
@@ -42,5 +42,10 @@
         /// content is defined for the containing ProductContent but some or all variants have not been extended.
         /// </remarks>
         bool HasProperty(string alias);
+
+        /// <summary>
+        /// Gets the default variant to display
+        /// </summary>
+        bool IsDefault { get; }
     }
 }

--- a/src/Merchello.Web/Models/VirtualContent/ProductVariantContent.cs
+++ b/src/Merchello.Web/Models/VirtualContent/ProductVariantContent.cs
@@ -192,6 +192,16 @@
         }
 
         /// <summary>
+        /// Is this the default variant to display
+        /// </summary>
+        public bool IsDefault {
+            get
+            {
+                return _variant.IsDefault;
+            }
+        }
+
+        /// <summary>
         /// Gets the product variant display.
         /// </summary>
         internal ProductVariantDisplay ProductVariantDisplay

--- a/src/Merchello.Web/UmbracoApplicationEventHandler.cs
+++ b/src/Merchello.Web/UmbracoApplicationEventHandler.cs
@@ -1,4 +1,8 @@
-﻿namespace Merchello.Web
+﻿using System.Collections.Generic;
+using Merchello.Web.Models.ContentEditing;
+using Merchello.Web.Models.VirtualContent;
+
+namespace Merchello.Web
 {
     using System;
     using System.Linq;
@@ -143,11 +147,47 @@
             ProductService.AddedToCollection += ProductServiceAddedToCollection;
             ProductService.RemovedFromCollection += ProductServiceRemovedFromCollection;
             ProductService.Deleted += ProductServiceDeleted;
+            ProductService.Saved += ProductServiceOnSaved;
 
             EntityCollectionService.Saved += EntityCollectionSaved;
             EntityCollectionService.Deleted += EntityCollectionDeleted;
 
             if (merchelloIsStarted) this.VerifyMerchelloVersion();
+        }
+
+        private void ProductServiceOnSaved(IProductService sender, SaveEventArgs<IProduct> e)
+        {
+            // On save we need to set the default variant if it has variants
+            foreach (var eSavedEntity in e.SavedEntities)
+            {
+                if (eSavedEntity.ProductVariants.Any())
+                {
+                    // TODO: Must be a better way of doing this as it seems very hacky and open to things screwing up, but default variant was not implemented correctly
+                    // TODO: so this is a work around to save a TON of refactoring/reworking and breaking changes to existing stores
+
+                    var productContent = eSavedEntity.ToProductDisplay().AsProductContent();
+                    var defaultVariant = productContent.GetDefaultProductVariant();
+
+                    // Get the default one
+                    foreach (var productVariant in eSavedEntity.ProductVariants)
+                    {
+                        if (defaultVariant.Key == productVariant.Key && productVariant.IsDefault == false)
+                        {
+                            productVariant.IsDefault = true;
+                        }
+                        else if(defaultVariant.Key != productVariant.Key && productVariant.IsDefault)
+                        {
+                            productVariant.IsDefault = false;
+                        }
+
+                        if (productVariant.IsDirty())
+                        {
+                            MerchelloContext.Current.Services.ProductVariantService.Save(productVariant, false);
+                        }
+                    }
+
+                }
+            }
         }
 
         private void EntityCollectionSaved(IEntityCollectionService sender, SaveEventArgs<Core.Models.Interfaces.IEntityCollection> e)

--- a/test/Merchello.Tests.IntegrationTests/DisplayClasses/ProductDisplayTests.cs
+++ b/test/Merchello.Tests.IntegrationTests/DisplayClasses/ProductDisplayTests.cs
@@ -149,6 +149,7 @@ namespace Merchello.Tests.IntegrationTests.DisplayClasses
             Assert.AreEqual(productVariant.Sku, productVariantDisplay.Sku);
             Assert.AreEqual(productVariant.Price, productVariantDisplay.Price);
             Assert.AreEqual(productVariant.ProductKey, productVariantDisplay.ProductKey);
+            Assert.AreEqual(productVariant.IsDefault, productVariantDisplay.IsDefault);
             Assert.AreEqual(productVariant.TrackInventory, productVariantDisplay.TrackInventory);
             Assert.AreEqual(productVariant.Attributes.Count(), productVariantDisplay.Attributes.Count());
             Assert.IsTrue(productVariantDisplay.CatalogInventories.Any());

--- a/test/Merchello.Tests.UnitTests/Models/ProductTests.cs
+++ b/test/Merchello.Tests.UnitTests/Models/ProductTests.cs
@@ -15,7 +15,7 @@ namespace Merchello.Tests.UnitTests.Models
         public void Init()
         {
             var variant = new ProductVariant(Guid.NewGuid(), new ProductAttributeCollection(),
-                new CatalogInventoryCollection(), true, "Product Name", "TestSku", 10M);
+                new CatalogInventoryCollection(), true, false, "Product Name", "TestSku", 10M);
             _product = new Product(variant);
         }
 
@@ -77,7 +77,7 @@ namespace Merchello.Tests.UnitTests.Models
             var att = new ProductAttribute("Choice1", "choice") { Key = Guid.NewGuid() };
             var attCollection = new ProductAttributeCollection();
             attCollection.Add(att);
-            var expected = new ProductVariant(Guid.NewGuid(), attCollection, new CatalogInventoryCollection(), false,
+            var expected = new ProductVariant(Guid.NewGuid(), attCollection, new CatalogInventoryCollection(), false, false,
                 "Variant", "variant", 5M);
             _product.ProductOptions.Add(new ProductOption("Option1") { Key = Guid.NewGuid() });
             _product.ProductOptions.First(x => x.Name == "Option1").Choices.Add(att);
@@ -102,7 +102,7 @@ namespace Merchello.Tests.UnitTests.Models
             var att = new ProductAttribute("Choice1", "choice") { Key = Guid.NewGuid() };
             var key = att.Key;
             var attCollection = new ProductAttributeCollection {att};
-            var expected = new ProductVariant(Guid.NewGuid(), attCollection, new CatalogInventoryCollection(), false,
+            var expected = new ProductVariant(Guid.NewGuid(), attCollection, new CatalogInventoryCollection(), false, false,
                 "Variant", "variant", 5M);
             _product.ProductOptions.Add(new ProductOption("Option1") { Key = Guid.NewGuid() });
             _product.ProductOptions.First(x => x.Name == "Option1").Choices.Add(att);
@@ -123,7 +123,7 @@ namespace Merchello.Tests.UnitTests.Models
             var att = new ProductAttribute("Choice1", "choice") { Key = Guid.NewGuid() };
             var attCollection = new ProductAttributeCollection();
             attCollection.Add(att);
-            var expected = new ProductVariant(Guid.NewGuid(), attCollection, new CatalogInventoryCollection(), false,
+            var expected = new ProductVariant(Guid.NewGuid(), attCollection, new CatalogInventoryCollection(), false, false,
                 "Variant", "variant", 5M);
             _product.ProductOptions.Add(new ProductOption("Option1") { Key = Guid.NewGuid() });
             _product.ProductOptions.First(x => x.Name == "Option1").Choices.Add(att);

--- a/test/Merchello.Tests.UnitTests/Models/ProductVariantTests.cs
+++ b/test/Merchello.Tests.UnitTests/Models/ProductVariantTests.cs
@@ -21,7 +21,7 @@ namespace Merchello.Tests.UnitTests.Models
                     new ProductAttribute("Att3", "Sku3") { Key = Guid.NewGuid() }
                 };
 
-            _productVariant = new ProductVariant(Guid.NewGuid(), _attributes, new CatalogInventoryCollection(), false, "Product1", "P1", 11M);
+            _productVariant = new ProductVariant(Guid.NewGuid(), _attributes, new CatalogInventoryCollection(), false, false, "Product1", "P1", 11M);
         }
 
         /// <summary>


### PR DESCRIPTION
The main issue with Merchello is everything is key'd off the productKey when it should be the variant key. Also getting the default variant (i.e. Selected variant from options) is very inefficient and not implemented correctly. Meaning you can't query for the default variant to display, without getting the products and then fishing through the variants (Could be 10's of thousands).

I've added a work around for people who are custom querying at a variant level, which lets you return the default variants. If you want to use this, you need to put the merchello version in the web.config back to 2.6 so the migration kicks in and adds the new DB column on the merchProductVariant table.  

The nightlies can be found here, use at your own risk.

https://www.myget.org/F/merchello-dev/api/v3/index.json

See code comments for more info.
src/Merchello.Web/UmbracoApplicationEventHandler.cs