### PR TITLE
Ability to restrict Tree's via User Groups

### DIFF
--- a/src/Merchello.Core/UmbracoApplicationEventHandler.cs
+++ b/src/Merchello.Core/UmbracoApplicationEventHandler.cs
@@ -1,42 +1,45 @@
-﻿namespace Merchello.Core
+﻿using Merchello.Core.Models;
+using Merchello.Core.Services;
+using Umbraco.Core;
+using Umbraco.Core.Events;
+
+namespace Merchello.Core
 {
-    using Merchello.Core.Services;
-
-    using Umbraco.Core;
-
     /// <summary>
-    /// Handles the Umbraco Application "Starting" and "Started" event and initiates the Merchello startup
+    ///     Handles the Umbraco Application "Starting" and "Started" event and initiates the Merchello startup
     /// </summary>
     public class UmbracoApplicationEventHandler : ApplicationEventHandler
     {
         /// <summary>
-        /// The Umbraco Application Starting event.
+        ///     The Umbraco Application Starting event.
         /// </summary>
         /// <param name="umbracoApplication">
-        /// The umbraco application.
+        ///     The umbraco application.
         /// </param>
         /// <param name="applicationContext">
-        /// The application context.
+        ///     The application context.
         /// </param>
-        protected override void ApplicationStarted(UmbracoApplicationBase umbracoApplication, ApplicationContext applicationContext)
+        protected override void ApplicationStarted(UmbracoApplicationBase umbracoApplication,
+            ApplicationContext applicationContext)
         {
             base.ApplicationStarted(umbracoApplication, applicationContext);
 
             StoreSettingService.Saved += StoreSettingServiceSaved;
         }
 
+
         /// <summary>
-        /// Resets the store currency.
+        ///     Resets the store currency.
         /// </summary>
         /// <param name="sender">
-        /// The sender.
+        ///     The sender.
         /// </param>
         /// <param name="e">
-        /// The save event args.
+        ///     The save event args.
         /// </param>
         private void StoreSettingServiceSaved(
             IStoreSettingService sender,
-            Umbraco.Core.Events.SaveEventArgs<Models.IStoreSetting> e)
+            SaveEventArgs<IStoreSetting> e)
         {
             CurrencyContext.Current.ResetCurrency();
         }

--- a/src/Merchello.FastTrack.Ui/App_Plugins/Merchello/config/merchello.config
+++ b/src/Merchello.FastTrack.Ui/App_Plugins/Merchello/config/merchello.config
@@ -105,6 +105,13 @@
                 after.
             -->
             <setting alias="selfManagedProvidersBeforeStaticProviders" value="true" />
+
+            <!--
+                This is used to restrict access to specific tree's to certain 
+                user group alias's. The value must be a comma seperated list (CSV). i.e. admin,customAlias
+                If missing or empty it will allow any group access as it does by default
+            -->
+            <setting alias="allowedUserGroupAliases" value="admin" />
         </childSettings>
         <selfManagedEntityCollectionProviders>
             <!--
@@ -124,7 +131,11 @@
     </tree>
     <tree id="customers" title="Customers" icon="icon-user-glasses" routePath="merchello/merchello/customerlist/manage" visible="true" sortOrder="3" />
     <tree id="marketing" title="Marketing" icon="icon-energy-saving-bulb" routePath="merchello/merchello/offerslist/manage" visible="true" sortOrder="4" />
-    <tree id="reports" title="Reports" icon="icon-slideshow" routePath="merchello/merchello/reportsdashboard/manage" visible="true" sortOrder="5" />
+    <tree id="reports" title="Reports" icon="icon-slideshow" routePath="merchello/merchello/reportsdashboard/manage" visible="true" sortOrder="5">
+      <childSettings>
+        <setting alias="allowedUserGroupAliases" value="admin" />
+      </childSettings>
+    </tree>
     <tree id="gateways" title="Gateway Providers" icon="icon-settings" routePath="merchello/merchello/gatewayproviderlist/manage" visible="true" sortOrder="6" />
   </backoffice>
 

--- a/src/Merchello.FastTrack.Ui/App_Plugins/Merchello/config/merchello.config
+++ b/src/Merchello.FastTrack.Ui/App_Plugins/Merchello/config/merchello.config
@@ -111,7 +111,7 @@
                 user group alias's. The value must be a comma seperated list (CSV). i.e. admin,customAlias
                 If missing or empty it will allow any group access as it does by default
             -->
-            <setting alias="allowedUserGroupAliases" value="admin" />
+            <setting alias="allowedUserGroupAliases" value="" />
         </childSettings>
         <selfManagedEntityCollectionProviders>
             <!--
@@ -131,11 +131,7 @@
     </tree>
     <tree id="customers" title="Customers" icon="icon-user-glasses" routePath="merchello/merchello/customerlist/manage" visible="true" sortOrder="3" />
     <tree id="marketing" title="Marketing" icon="icon-energy-saving-bulb" routePath="merchello/merchello/offerslist/manage" visible="true" sortOrder="4" />
-    <tree id="reports" title="Reports" icon="icon-slideshow" routePath="merchello/merchello/reportsdashboard/manage" visible="true" sortOrder="5">
-      <childSettings>
-        <setting alias="allowedUserGroupAliases" value="admin" />
-      </childSettings>
-    </tree>
+    <tree id="reports" title="Reports" icon="icon-slideshow" routePath="merchello/merchello/reportsdashboard/manage" visible="true" sortOrder="5" />
     <tree id="gateways" title="Gateway Providers" icon="icon-settings" routePath="merchello/merchello/gatewayproviderlist/manage" visible="true" sortOrder="6" />
   </backoffice>
 

--- a/src/Merchello.Web.UI.Client/src/config/merchello.config
+++ b/src/Merchello.Web.UI.Client/src/config/merchello.config
@@ -105,6 +105,13 @@
                 after.
             -->
             <setting alias="selfManagedProvidersBeforeStaticProviders" value="true" />
+
+            <!--
+                This is used to restrict access to specific tree's to certain 
+                user group alias's. The value must be a comma seperated list (CSV). i.e. admin,customAlias
+                If missing or empty it will allow any group access as it does by default
+            -->
+            <setting alias="allowedUserGroupAliases" value="admin" />
         </childSettings>
         <selfManagedEntityCollectionProviders>
             <!--
@@ -124,7 +131,11 @@
     </tree>
     <tree id="customers" title="Customers" icon="icon-user-glasses" routePath="merchello/merchello/customerlist/manage" visible="true" sortOrder="3" />
     <tree id="marketing" title="Marketing" icon="icon-energy-saving-bulb" routePath="merchello/merchello/offerslist/manage" visible="true" sortOrder="4" />
-    <tree id="reports" title="Reports" icon="icon-slideshow" routePath="merchello/merchello/reportsdashboard/manage" visible="true" sortOrder="5" />
+    <tree id="reports" title="Reports" icon="icon-slideshow" routePath="merchello/merchello/reportsdashboard/manage" visible="true" sortOrder="5">
+      <childSettings>
+        <setting alias="allowedUserGroupAliases" value="admin" />
+      </childSettings>
+    </tree>
     <tree id="gateways" title="Gateway Providers" icon="icon-settings" routePath="merchello/merchello/gatewayproviderlist/manage" visible="true" sortOrder="6" />
   </backoffice>
 

--- a/src/Merchello.Web.UI.Client/src/config/merchello.config
+++ b/src/Merchello.Web.UI.Client/src/config/merchello.config
@@ -111,7 +111,7 @@
                 user group alias's. The value must be a comma seperated list (CSV). i.e. admin,customAlias
                 If missing or empty it will allow any group access as it does by default
             -->
-            <setting alias="allowedUserGroupAliases" value="admin" />
+            <setting alias="allowedUserGroupAliases" value="" />
         </childSettings>
         <selfManagedEntityCollectionProviders>
             <!--
@@ -131,11 +131,7 @@
     </tree>
     <tree id="customers" title="Customers" icon="icon-user-glasses" routePath="merchello/merchello/customerlist/manage" visible="true" sortOrder="3" />
     <tree id="marketing" title="Marketing" icon="icon-energy-saving-bulb" routePath="merchello/merchello/offerslist/manage" visible="true" sortOrder="4" />
-    <tree id="reports" title="Reports" icon="icon-slideshow" routePath="merchello/merchello/reportsdashboard/manage" visible="true" sortOrder="5">
-      <childSettings>
-        <setting alias="allowedUserGroupAliases" value="admin" />
-      </childSettings>
-    </tree>
+    <tree id="reports" title="Reports" icon="icon-slideshow" routePath="merchello/merchello/reportsdashboard/manage" visible="true" sortOrder="5" />
     <tree id="gateways" title="Gateway Providers" icon="icon-settings" routePath="merchello/merchello/gatewayproviderlist/manage" visible="true" sortOrder="6" />
   </backoffice>
 

--- a/src/Merchello.Web/UmbracoApplicationEventHandler.cs
+++ b/src/Merchello.Web/UmbracoApplicationEventHandler.cs
@@ -1,6 +1,11 @@
 ﻿using System.Collections.Generic;
+using System.Web;
+using Merchello.Core.Configuration.Outline;
 using Merchello.Web.Models.ContentEditing;
 using Merchello.Web.Models.VirtualContent;
+using Newtonsoft.Json;
+using Umbraco.Core.Security;
+using Umbraco.Web.Trees;
 
 namespace Merchello.Web
 {
@@ -153,8 +158,52 @@ namespace Merchello.Web
             EntityCollectionService.Saved += EntityCollectionSaved;
             EntityCollectionService.Deleted += EntityCollectionDeleted;
 
+            TreeControllerBase.TreeNodesRendering += TreeControllerBaseOnTreeNodesRendering;
+
             if (merchelloIsStarted) this.VerifyMerchelloVersion();
         }
+
+        private void TreeControllerBaseOnTreeNodesRendering(TreeControllerBase sender, TreeNodesRenderingEventArgs e)
+        {
+            // this example will filter any content tree node whose node name starts with
+            // 'Private', for any user that is of the type 'customUser'
+
+            var ticket = new HttpContextWrapper(HttpContext.Current).GetUmbracoAuthTicket();
+            if (ticket != null)
+            {
+                // Get a list of trees/nodes for Merchello
+                var backoffice = MerchelloConfiguration.Current.BackOffice
+                    .GetTrees()
+                    .Where(x => x.Visible)
+                    .ToDictionary(x => x.Id, x => x.ChildSettings.AllSettings().FirstOrDefault(s => s.Alias == "allowedUserGroupAliases"));
+
+                // Get the users groups from the ticket
+                var userData = new { Name = "", Username = "", Roles = new List<string>() };
+                var jsonResponse = JsonConvert.DeserializeAnonymousType(ticket.UserData, userData);
+
+                var toRemove = new List<object>();
+                foreach (var eNode in e.Nodes)
+                {
+                    var nodeId = eNode.Id.ToString();
+                    if (!string.IsNullOrWhiteSpace(nodeId) && backoffice.ContainsKey(nodeId))
+                    {
+                        var allowedUserGroups = backoffice[nodeId];
+                        if (allowedUserGroups != null && !string.IsNullOrWhiteSpace(allowedUserGroups.Value))
+                        {
+
+
+                            //toRemove.Add(eNode.Id);
+                        }
+                    }
+                }
+
+                if (toRemove.Any())
+                {
+                    e.Nodes.RemoveAll(x => toRemove.Contains(x.Id));
+                }
+            }
+        }
+
 
         /// <summary>
         /// Product service saved

--- a/src/Merchello.Web/UmbracoApplicationEventHandler.cs
+++ b/src/Merchello.Web/UmbracoApplicationEventHandler.cs
@@ -190,11 +190,32 @@ namespace Merchello.Web
                         var allowedUserGroups = backoffice[nodeId];
                         if (allowedUserGroups != null && !string.IsNullOrWhiteSpace(allowedUserGroups.Value))
                         {
+                            var allowedUserGroupList = allowedUserGroups.Value.Split(',')
+                                                        .Select(x => x.Trim())
+                                                        .Where(x => !string.IsNullOrWhiteSpace(x))
+                                                        .ToArray();
 
+                            var isAllowedAccess = false;
+                            foreach (var role in jsonResponse.Roles)
+                            {
+                                foreach (var s in allowedUserGroupList)
+                                {
+                                    if (s == role)
+                                    {
+                                        isAllowedAccess = true;
+                                        goto CheckAccess;
+                                    }
+                                }
+                            }
+                            CheckAccess:
 
-                            //toRemove.Add(eNode.Id);
+                            if (isAllowedAccess == false)
+                            {
+                                toRemove.Add(eNode.Id);
+                            }
                         }
                     }
+                    
                 }
 
                 if (toRemove.Any())


### PR DESCRIPTION
New setting in the merchello config under the Tree sections allow you to put user group aliases in. If entered, and user it not in that group the tree won't display.