### PR TITLE
Feature/add items overload

### DIFF
--- a/src/Merchello.Web/Merchello.Web.csproj
+++ b/src/Merchello.Web/Merchello.Web.csproj
@@ -224,7 +224,7 @@
       <HintPath>..\packages\UmbracoCms.Core.7.15.0\lib\net452\umbraco.dll</HintPath>
     </Reference>
     <Reference Include="Umbraco.Core, Version=1.0.7128.14457, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\UmbracoCms.Core.7.15.0\lib\net452\Umbraco.Core.dll</HintPath>
+      <HintPath>..\Merchello.FastTrack.Ui\Bin\Umbraco.Core.dll</HintPath>
     </Reference>
     <Reference Include="umbraco.DataLayer, Version=1.0.7128.14461, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\UmbracoCms.Core.7.15.0\lib\net452\umbraco.DataLayer.dll</HintPath>

--- a/src/Merchello.Web/Merchello.Web.csproj
+++ b/src/Merchello.Web/Merchello.Web.csproj
@@ -224,7 +224,7 @@
       <HintPath>..\packages\UmbracoCms.Core.7.15.0\lib\net452\umbraco.dll</HintPath>
     </Reference>
     <Reference Include="Umbraco.Core, Version=1.0.7128.14457, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\Merchello.FastTrack.Ui\Bin\Umbraco.Core.dll</HintPath>
+      <HintPath>..\packages\UmbracoCms.Core.7.15.0\lib\net452\Umbraco.Core.dll</HintPath>
     </Reference>
     <Reference Include="umbraco.DataLayer, Version=1.0.7128.14461, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\UmbracoCms.Core.7.15.0\lib\net452\umbraco.DataLayer.dll</HintPath>

--- a/src/Merchello.Web/Workflow/CustomerItemCache/CustomerItemCacheBase.cs
+++ b/src/Merchello.Web/Workflow/CustomerItemCache/CustomerItemCacheBase.cs
@@ -220,6 +220,19 @@
         }
 
         /// <summary>
+        /// Adds a <see cref="IProduct"/> to the item cache
+        /// </summary>
+        /// <param name="product">The <see cref="IProduct"/> to be added</param>
+        /// <param name="extendedData">The <see cref="ExtendedDataCollection"/>.</param>
+        /// <remarks>
+        /// If the product has variants, the "first" variant found will be added.
+        /// </remarks>
+        public void AddItem(IProduct product, ExtendedDataCollection extendedData)
+        {
+            AddItem(product, product.Name, 1, extendedData);
+        }
+
+        /// <summary>
         /// Intended to be used by a <see cref="IProduct"/>s without options.  If the product does have options and a collection of <see cref="IProductVariant"/>s, the first
         /// <see cref="IProductVariant"/> is added to the customer item cache item collection
         /// </summary>
@@ -232,6 +245,20 @@
         public void AddItem(IProduct product, int quantity)
         {
             AddItem(product, product.Name, quantity);
+        }
+
+        /// <summary>
+        /// Adds a <see cref="IProduct"/> to the item cache
+        /// </summary>
+        /// <param name="product">The <see cref="IProduct"/> to be added</param>
+        /// <param name="quantity">The quantity to be represented</param>
+        /// <param name="extendedData">The <see cref="ExtendedDataCollection"/>.</param>
+        /// <remarks>
+        /// If the product has variants, the "first" variant found will be added.
+        /// </remarks>
+        public void AddItem(IProduct product, int quantity, ExtendedDataCollection extendedData)
+        {
+            AddItem(product, product.Name, quantity, extendedData);
         }
 
         /// <summary>
@@ -339,7 +366,6 @@
 
         #endregion
 
-
         #region IProductVariant
 
         /// <summary>
@@ -354,6 +380,16 @@
         }
 
         /// <summary>
+        /// Adds a <see cref="IProductVariant"/> to the item cache
+        /// </summary>
+        /// <param name="productVariant">The product variant to be added</param>
+        /// <param name="extendedData">The <see cref="ExtendedDataCollection"/>.</param>
+        public void AddItem(IProductVariant productVariant, ExtendedDataCollection extendedData)
+        {
+            AddItem(productVariant, productVariant.Name, 1, extendedData);
+        }
+
+        /// <summary>
         /// Adds a line item to the customer item cache
         /// </summary>
         /// <param name="productVariant">
@@ -365,6 +401,17 @@
         public void AddItem(IProductVariant productVariant, int quantity)
         {
             AddItem(productVariant, productVariant.Name, quantity);
+        }
+
+        /// <summary>
+        /// Adds a <see cref="IProductVariant"/> to the item cache
+        /// </summary>
+        /// <param name="productVariant">The product variant to be added</param>
+        /// <param name="quantity">The quantity to be represented</param>
+        /// <param name="extendedData">The <see cref="ExtendedDataCollection"/>.</param>
+        public void AddItem(IProductVariant productVariant, int quantity, ExtendedDataCollection extendedData)
+        {
+            AddItem(productVariant, productVariant.Name, quantity, extendedData);
         }
 
         /// <summary>
@@ -421,6 +468,16 @@
         /// Adds a <see cref="ProductVariantDisplay"/> to the item cache
         /// </summary>
         /// <param name="productVariant">The product variant to be added</param>
+        /// <param name="extendedData">The <see cref="ExtendedDataCollection"/>.</param>
+        public void AddItem(ProductVariantDisplay productVariant, ExtendedDataCollection extendedData)
+        {
+            AddItem(productVariant, productVariant.Name, 1, extendedData);
+        }
+
+        /// <summary>
+        /// Adds a <see cref="ProductVariantDisplay"/> to the item cache
+        /// </summary>
+        /// <param name="productVariant">The product variant to be added</param>
         /// <param name="quantity">The quantity to be represented</param>
         public void AddItem(ProductVariantDisplay productVariant, int quantity)
         {
@@ -442,6 +499,17 @@
         public void AddItem(ProductVariantDisplay productVariant, string name, int quantity)
         {
             AddItem(productVariant, name, quantity, new ExtendedDataCollection());
+        }
+
+        /// <summary>
+        /// Adds a <see cref="ProductVariantDisplay"/> to the item cache
+        /// </summary>
+        /// <param name="productVariant">The product variant to be added</param>
+        /// <param name="quantity">The quantity to be represented</param>
+        /// <param name="extendedData">The <see cref="ExtendedDataCollection"/>.</param>
+        public void AddItem(ProductVariantDisplay productVariant, int quantity, ExtendedDataCollection extendedData)
+        {
+            AddItem(productVariant, productVariant.Name, quantity, extendedData);
         }
 
         /// <summary>
@@ -790,7 +858,5 @@
             _itemCache.Items.AddingItem += ItemsOnAddingItem;
             Validated += OnValidated;
         }
-
-
     }
 }

--- a/src/Merchello.Web/Workflow/CustomerItemCache/ICustomerItemCacheBase.cs
+++ b/src/Merchello.Web/Workflow/CustomerItemCache/ICustomerItemCacheBase.cs
@@ -186,6 +186,12 @@
         /// Adds a <see cref="IProductVariant"/> to the item cache
         /// </summary>
         /// <param name="productVariant">The product variant to be added</param>
+        void AddItem(IProductVariant productVariant);
+
+        /// <summary>
+        /// Adds a <see cref="IProductVariant"/> to the item cache
+        /// </summary>
+        /// <param name="productVariant">The product variant to be added</param>
         /// <param name="extendedData">The <see cref="ExtendedDataCollection"/>.</param>
         void AddItem(IProductVariant productVariant, ExtendedDataCollection extendedData);
 

--- a/src/Merchello.Web/Workflow/CustomerItemCache/ICustomerItemCacheBase.cs
+++ b/src/Merchello.Web/Workflow/CustomerItemCache/ICustomerItemCacheBase.cs
@@ -65,11 +65,32 @@
         /// Adds a <see cref="IProduct"/> to the item cache
         /// </summary>
         /// <param name="product">The <see cref="IProduct"/> to be added</param>
+        /// <param name="extendedData">The <see cref="ExtendedDataCollection"/>.</param>
+        /// <remarks>
+        /// If the product has variants, the "first" variant found will be added.
+        /// </remarks>
+        void AddItem(IProduct product, ExtendedDataCollection extendedData);
+
+        /// <summary>
+        /// Adds a <see cref="IProduct"/> to the item cache
+        /// </summary>
+        /// <param name="product">The <see cref="IProduct"/> to be added</param>
         /// <param name="quantity">The quantity to be represented</param>
         /// <remarks>
         /// If the product has variants, the "first" variant found will be added.
         /// </remarks>
         void AddItem(IProduct product, int quantity);
+
+        /// <summary>
+        /// Adds a <see cref="IProduct"/> to the item cache
+        /// </summary>
+        /// <param name="product">The <see cref="IProduct"/> to be added</param>
+        /// <param name="quantity">The quantity to be represented</param>
+        /// <param name="extendedData">The <see cref="ExtendedDataCollection"/>.</param>
+        /// <remarks>
+        /// If the product has variants, the "first" variant found will be added.
+        /// </remarks>
+        void AddItem(IProduct product, int quantity, ExtendedDataCollection extendedData);
 
         /// <summary>
         /// Adds a <see cref="IProduct"/> to the item cache
@@ -165,7 +186,8 @@
         /// Adds a <see cref="IProductVariant"/> to the item cache
         /// </summary>
         /// <param name="productVariant">The product variant to be added</param>
-        void AddItem(IProductVariant productVariant);
+        /// <param name="extendedData">The <see cref="ExtendedDataCollection"/>.</param>
+        void AddItem(IProductVariant productVariant, ExtendedDataCollection extendedData);
 
         /// <summary>
         /// Adds a <see cref="IProductVariant"/> to the item cache
@@ -173,6 +195,14 @@
         /// <param name="productVariant">The product variant to be added</param>
         /// <param name="quantity">The quantity to be represented</param>
         void AddItem(IProductVariant productVariant, int quantity);
+
+        /// <summary>
+        /// Adds a <see cref="IProductVariant"/> to the item cache
+        /// </summary>
+        /// <param name="productVariant">The product variant to be added</param>
+        /// <param name="quantity">The quantity to be represented</param>
+        /// <param name="extendedData">The <see cref="ExtendedDataCollection"/>.</param>
+        void AddItem(IProductVariant productVariant, int quantity, ExtendedDataCollection extendedData);
 
         /// <summary>
         /// Adds a <see cref="IProductVariant"/> to the item cache
@@ -219,8 +249,23 @@
         /// Adds a <see cref="ProductVariantDisplay"/> to the item cache
         /// </summary>
         /// <param name="productVariant">The product variant to be added</param>
+        /// <param name="extendedData">The <see cref="ExtendedDataCollection"/>.</param>
+        void AddItem(ProductVariantDisplay productVariant, ExtendedDataCollection extendedData);
+
+        /// <summary>
+        /// Adds a <see cref="ProductVariantDisplay"/> to the item cache
+        /// </summary>
+        /// <param name="productVariant">The product variant to be added</param>
         /// <param name="quantity">The quantity to be represented</param>
         void AddItem(ProductVariantDisplay productVariant, int quantity);
+
+        /// <summary>
+        /// Adds a <see cref="ProductVariantDisplay"/> to the item cache
+        /// </summary>
+        /// <param name="productVariant">The product variant to be added</param>
+        /// <param name="quantity">The quantity to be represented</param>
+        /// <param name="extendedData">The <see cref="ExtendedDataCollection"/>.</param>
+        void AddItem(ProductVariantDisplay productVariant, int quantity, ExtendedDataCollection extendedData);
 
         /// <summary>
         /// Adds a <see cref="ProductVariantDisplay"/> to the item cache


### PR DESCRIPTION
Adding more AddItems overload methods to ICustomerItemCacheBase. 

```
AddItem(IProduct product, ExtendedDataCollection extendedData)
AddItem(IProduct product, int quantity, ExtendedDataCollection extendedData)
AddItem(IProductVariant productVariant, ExtendedDataCollection extendedData)
AddItem(IProductVariant productVariant, int quantity, ExtendedDataCollection extendedData)
AddItem(ProductVariantDisplay productVariant, ExtendedDataCollection extendedData)
AddItem(ProductVariantDisplay productVariant, int quantity, ExtendedDataCollection extendedData)
```

Adding the ExtendedDataCollection parameter to different AddItems overload methods, gives the use more flexibility .